### PR TITLE
Revert API key responsibility to consuming app

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,42 @@ Render the element and include data:
 {% from "components/moj-map/macro.njk" import mojMap %}
 
 {{ mojMap({
+  apiKey: params.apiKey,
   cspNonce: cspNonce,
   // Optional renderer: "openlayers" (default) or "maplibre"
   renderer: "openlayers",
   vectorUrl: "https://api.os.uk/maps/vector/v1/vts"
+}) }}
+```
+
+---
+
+## API Key and Vector Tiles
+
+When using **vector tiles**, the Ordnance Survey API requires an access key.
+
+`<moj-map>` enforces this:
+
+- Either provide an **`apiKey`** attribute → the component will append `?key=...` to the `vectorUrl` automatically.
+- Or provide a **`vectorUrl`** that already includes `?key=YOUR_KEY`.
+
+### Example (using `apiKey`)
+
+```njk
+{{ mojMap({
+  cspNonce: cspNonce,
+  renderer: "openlayers",
+  apiKey: params.apiKey
+}) }}
+```
+
+### Example (using `vectorURL`)
+
+```njk
+{{ mojMap({
+  cspNonce: cspNonce,
+  renderer: "openlayers",
+  vectorUrl: "https://api.os.uk/maps/vector/v1/vts/resources/styles?srs=3857&key=YOUR_KEY"
 }) }}
 ```
 

--- a/nunjucks/components/moj-map/template.njk
+++ b/nunjucks/components/moj-map/template.njk
@@ -5,6 +5,7 @@
   {% if params.accessTokenUrl %}access-token-url="{{ params.accessTokenUrl }}"{% endif %}
   {% if params.vectorUrl %}vector-url="{{ params.vectorUrl }}"{% endif %}
   {% if params.tileUrl %}tile-url="{{ params.tileUrl }}"{% endif %}
+  {% if params.apiKey %}api-key="{{ params.apiKey }}"{% endif %}
   {% if params.renderer %}renderer="{{ params.renderer }}"{% endif %}
   {% if params.controls.scaleControl %}scale-control="{{ params.controls.scaleControl }}"{% endif %}
   {% if params.controls.zoomSlider %}zoom-slider{% endif %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmpps-open-layers-map",
-  "version": "0.6.61",
+  "version": "0.6.74",
   "description": "A native Web Component for displaying maps using OpenLayers.",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmpps-open-layers-map",
-  "version": "0.6.60",
+  "version": "0.6.61",
   "description": "A native Web Component for displaying maps using OpenLayers.",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.es.js",

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -10,7 +10,8 @@ const map = document.createElement('moj-map')
 map.setAttribute('enable-3d-buildings', '')
 
 // Core setup
-map.setAttribute('vector-url', config.tiles.urls.vectorUrl)
+map.setAttribute('api-key', import.meta.env.VITE_OS_API_KEY)
+map.setAttribute('vector-url', config.tiles.urls.vectorStyleUrl)
 map.setAttribute('tile-url', config.tiles.urls.tileUrl)
 map.setAttribute('csp-nonce', '1234abcd')
 map.setAttribute('uses-internal-overlays', '')

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -3,6 +3,9 @@ import config from './scripts/map/config'
 
 const map = document.createElement('moj-map')
 
+const apiKey = import.meta.env.VITE_OS_API_KEY
+const signedVectorUrl = `${config.tiles.urls.vectorStyleUrl + (config.tiles.urls.vectorStyleUrl.includes('?') ? '&' : '?')}key=${apiKey}`
+
 // Use MapLibre (not OpenLayers)
 // map.setAttribute('renderer', 'maplibre')
 
@@ -11,7 +14,7 @@ map.setAttribute('enable-3d-buildings', '')
 
 // Core setup
 map.setAttribute('api-key', import.meta.env.VITE_OS_API_KEY)
-map.setAttribute('vector-url', config.tiles.urls.vectorStyleUrl)
+map.setAttribute('vector-url', signedVectorUrl)
 map.setAttribute('tile-url', config.tiles.urls.tileUrl)
 map.setAttribute('csp-nonce', '1234abcd')
 map.setAttribute('uses-internal-overlays', '')

--- a/src/scripts/map/config.ts
+++ b/src/scripts/map/config.ts
@@ -22,7 +22,7 @@ const config = {
     zoom: { min: 7, max: 20 },
     urls: {
       vectorStyleUrl: `${VITE_OS_MAPS_VECTOR_ROOT}/resources/styles?srs=3857`,
-      vectorSourceUrl: `${VITE_OS_MAPS_VECTOR_ROOT}/vts`, // for tests/stubs
+      vectorSourceUrl: `${VITE_OS_MAPS_VECTOR_ROOT}`,
       tileUrl: VITE_OS_MAPS_TILE_URL,
     },
     defaultTokenUrl: '/map/token',

--- a/src/scripts/map/config.ts
+++ b/src/scripts/map/config.ts
@@ -1,35 +1,28 @@
 import { fromLonLat, transformExtent } from 'ol/proj'
 
-// UK bounding box (approximate for OS tiles)
 const ukProjectedBounds = [-9.01, 49.75, 2.01, 61.01]
 const ukCentre = [-2.547855, 54.00366]
 
-// Pull environment variables from .env
-const VITE_OS_API_KEY = import.meta.env.VITE_OS_API_KEY ?? ''
 const VITE_OS_MAPS_TILE_URL =
   import.meta.env.VITE_OS_MAPS_TILE_URL ?? 'https://api.os.uk/maps/raster/v1/zxy/Road_3857/{z}/{x}/{y}'
-const VITE_OS_MAPS_VECTOR_URL = import.meta.env.VITE_OS_MAPS_VECTOR_URL ?? 'https://api.os.uk/maps/vector/v1/vts'
+const VITE_OS_MAPS_VECTOR_ROOT = (
+  import.meta.env.VITE_OS_MAPS_VECTOR_URL ?? 'https://api.os.uk/maps/vector/v1/vts'
+).replace(/\/$/, '')
 
 const config = {
   view: {
-    zoom: {
-      min: 5,
-      max: 20,
-    },
+    zoom: { min: 5, max: 20 },
     default: {
       zoom: 13,
       extent: transformExtent(ukProjectedBounds, 'EPSG:4326', 'EPSG:3857'),
       centre: fromLonLat(ukCentre),
     },
   },
-  apiKey: VITE_OS_API_KEY,
   tiles: {
-    zoom: {
-      min: 7,
-      max: 20,
-    },
+    zoom: { min: 7, max: 20 },
     urls: {
-      vectorUrl: `${VITE_OS_MAPS_VECTOR_URL}/resources/styles?srs=3857&key=${VITE_OS_API_KEY}`,
+      vectorStyleUrl: `${VITE_OS_MAPS_VECTOR_ROOT}/resources/styles?srs=3857`,
+      vectorSourceUrl: `${VITE_OS_MAPS_VECTOR_ROOT}/vts`, // for tests/stubs
       tileUrl: VITE_OS_MAPS_TILE_URL,
     },
     defaultTokenUrl: '/map/token',

--- a/src/scripts/map/layers/ordnance-survey-vector.test.ts
+++ b/src/scripts/map/layers/ordnance-survey-vector.test.ts
@@ -81,4 +81,13 @@ describe('OrdnanceSurveyVectorTileLayer', () => {
     const result = await layer.applyVectorStyle('APIKEY', 'https://tiles.os.uk/styles/os.json')
     expect(result).toBe('STYLE_APPLIED')
   })
+
+  it('does not duplicate existing key', async () => {
+    const layer = new OrdnanceSurveyVectorTileLayer()
+    await layer.applyVectorStyle('APIKEY', 'https://api.os.uk/maps/vector/v1/resources/styles?srs=3857&key=PRESENT')
+    expect(applyStyle).toHaveBeenCalledWith(
+      layer,
+      'https://api.os.uk/maps/vector/v1/resources/styles?srs=3857&key=PRESENT',
+    )
+  })
 })

--- a/src/scripts/map/layers/ordnance-survey-vector.test.ts
+++ b/src/scripts/map/layers/ordnance-survey-vector.test.ts
@@ -55,39 +55,18 @@ describe('OrdnanceSurveyVectorTileLayer', () => {
   it('initialises with declutter = true', () => {
     const layer = new OrdnanceSurveyVectorTileLayer()
     expect(layer).toBeInstanceOf(OrdnanceSurveyVectorTileLayer)
-    expect(layer.get('declutter')).toBe(true) // ✅ no `as any`
+    expect(layer.get('declutter')).toBe(true)
   })
 
-  it('calls applyStyle with ?key= when no query params exist', async () => {
+  it('strips a single trailing slash before passing to applyStyle', async () => {
     const layer = new OrdnanceSurveyVectorTileLayer()
-    await layer.applyVectorStyle('APIKEY', 'https://tiles.os.uk/styles/os.json')
-    expect(applyStyle).toHaveBeenCalledWith(layer, 'https://tiles.os.uk/styles/os.json?key=APIKEY')
-  })
-
-  it('calls applyStyle with &key= when query params exist', async () => {
-    const layer = new OrdnanceSurveyVectorTileLayer()
-    await layer.applyVectorStyle('APIKEY', 'https://tiles.os.uk/styles/os.json?foo=bar')
-    expect(applyStyle).toHaveBeenCalledWith(layer, 'https://tiles.os.uk/styles/os.json?foo=bar&key=APIKEY')
-  })
-
-  it('strips trailing slash before appending', async () => {
-    const layer = new OrdnanceSurveyVectorTileLayer()
-    await layer.applyVectorStyle('APIKEY', 'https://tiles.os.uk/styles/')
-    expect(applyStyle).toHaveBeenCalledWith(layer, 'https://tiles.os.uk/styles?key=APIKEY')
+    await layer.applyVectorStyle('https://tiles.os.uk/styles/')
+    expect(applyStyle).toHaveBeenCalledWith(layer, 'https://tiles.os.uk/styles')
   })
 
   it('returns the result of applyStyle', async () => {
     const layer = new OrdnanceSurveyVectorTileLayer()
-    const result = await layer.applyVectorStyle('APIKEY', 'https://tiles.os.uk/styles/os.json')
+    const result = await layer.applyVectorStyle('https://tiles.os.uk/styles/os.json')
     expect(result).toBe('STYLE_APPLIED')
-  })
-
-  it('does not duplicate existing key', async () => {
-    const layer = new OrdnanceSurveyVectorTileLayer()
-    await layer.applyVectorStyle('APIKEY', 'https://api.os.uk/maps/vector/v1/resources/styles?srs=3857&key=PRESENT')
-    expect(applyStyle).toHaveBeenCalledWith(
-      layer,
-      'https://api.os.uk/maps/vector/v1/resources/styles?srs=3857&key=PRESENT',
-    )
   })
 })

--- a/src/scripts/map/layers/ordnance-survey-vector.ts
+++ b/src/scripts/map/layers/ordnance-survey-vector.ts
@@ -9,20 +9,12 @@ export function resolveTileType(requested: string | null): TileType {
   return supportsWebGL() ? 'vector' : 'raster'
 }
 
-function formatVectorURL(styleBaseUrl: string, apiKey?: string): string {
-  const clean = styleBaseUrl.replace(/\/$/, '')
-  if (!apiKey) return clean
-  const url = new URL(clean, window.location.origin)
-  if (!url.searchParams.has('key')) url.searchParams.set('key', apiKey)
-  return url.toString()
-}
-
 export class OrdnanceSurveyVectorTileLayer extends VectorTileLayer {
   constructor() {
     super({ declutter: true })
   }
 
-  async applyVectorStyle(apiKey: string | undefined, styleBaseUrl: string): Promise<void> {
-    return applyStyle(this, formatVectorURL(styleBaseUrl, apiKey))
+  async applyVectorStyle(styleUrl: string): Promise<void> {
+    return applyStyle(this, styleUrl.replace(/\/$/, ''))
   }
 }

--- a/src/scripts/map/layers/ordnance-survey-vector.ts
+++ b/src/scripts/map/layers/ordnance-survey-vector.ts
@@ -9,17 +9,20 @@ export function resolveTileType(requested: string | null): TileType {
   return supportsWebGL() ? 'vector' : 'raster'
 }
 
+function formatVectorURL(styleBaseUrl: string, apiKey?: string): string {
+  const clean = styleBaseUrl.replace(/\/$/, '')
+  if (!apiKey) return clean
+  const url = new URL(clean, window.location.origin)
+  if (!url.searchParams.has('key')) url.searchParams.set('key', apiKey)
+  return url.toString()
+}
+
 export class OrdnanceSurveyVectorTileLayer extends VectorTileLayer {
   constructor() {
-    super({
-      declutter: true,
-    })
+    super({ declutter: true })
   }
 
-  async applyVectorStyle(apiKey: string, baseUrl: string): Promise<void> {
-    const cleanBaseUrl = baseUrl.replace(/\/$/, '')
-    const separator = cleanBaseUrl.includes('?') ? '&' : '?'
-    const styleUrl = `${cleanBaseUrl}${separator}key=${apiKey}`
-    return applyStyle(this, styleUrl)
+  async applyVectorStyle(apiKey: string | undefined, styleBaseUrl: string): Promise<void> {
+    return applyStyle(this, formatVectorURL(styleBaseUrl, apiKey))
   }
 }

--- a/src/scripts/map/layers/tracks-layer.ts
+++ b/src/scripts/map/layers/tracks-layer.ts
@@ -69,7 +69,7 @@ export class TracksLayer implements ComposableLayer<LayerGroup> {
       geoJson: this.options.geoJson,
       ...(this.options.lines ?? {}),
       id: `${this.id}-lines`,
-      title: this.options.title ?? 'tracksLayer',
+      title: this.options.lines?.title ?? 'linesLayer',
     } as LinesLayerConstructorOptions)
 
     lines.attach(adapter)
@@ -90,7 +90,7 @@ export class TracksLayer implements ComposableLayer<LayerGroup> {
         geoJson: this.options.geoJson,
         ...(this.options.arrows ?? {}),
         id: `${this.id}-arrows`,
-        title: (this.options.title ? `${this.options.title} arrows` : undefined) ?? 'arrowsLayer',
+        title: this.options.arrows?.title ?? 'arrowsLayer',
       } as ArrowsLayerConstructorOptions)
 
       arrows.attach(adapter)

--- a/src/scripts/map/setup/setup-openlayers-map.test.ts
+++ b/src/scripts/map/setup/setup-openlayers-map.test.ts
@@ -1,13 +1,16 @@
 import { setupOpenLayersMap } from './setup-openlayers-map'
 import { OLMapInstance } from '../open-layers-map-instance'
+import type { OLMapOptions } from '../open-layers-map-instance'
 import MapPointerInteraction from '../interactions/map-pointer-interaction'
 
 jest.mock('../open-layers-map-instance')
 jest.mock('../config', () => ({
-  apiKey: 'fake-key',
   tiles: {
     zoom: { min: 0, max: 20 },
-    urls: { tileUrl: 'http://fake-tiles', vectorUrl: 'http://fake-vector' },
+    urls: {
+      tileUrl: 'http://fake-tiles',
+      vectorStyleUrl: 'http://fake-vector/resources/styles?srs=3857',
+    },
     defaultTokenUrl: 'http://fake-token',
   },
 }))
@@ -60,7 +63,7 @@ describe('setupOpenLayersMap', () => {
       tileUrl: '',
       vectorUrl: '',
       usesInternalOverlays: false,
-      controls: { grabCursor: false } as any,
+      controls: { grabCursor: false } as unknown as OLMapOptions['controls'],
     })
 
     expect(addInteraction).not.toHaveBeenCalledWith(expect.any(MapPointerInteraction))

--- a/src/scripts/moj-map.test.ts
+++ b/src/scripts/moj-map.test.ts
@@ -12,7 +12,10 @@ jest.mock('./helpers/dom', () => ({
 jest.mock('./map/config', () => ({
   default: {
     tiles: {
-      urls: { tileUrl: 'https://mock-tiles', vectorUrl: 'https://mock-vector' },
+      urls: {
+        tileUrl: 'https://mock-tiles',
+        vectorStyleUrl: 'https://mock-vector',
+      },
       defaultTokenUrl: 'https://mock-token',
     },
   },
@@ -64,6 +67,7 @@ describe('MojMap', () => {
     mojMap.setAttribute('tile-url', 'https://attr-tiles')
     mojMap.setAttribute('vector-url', 'https://attr-vector')
     mojMap.setAttribute('access-token-url', 'none')
+    mojMap.setAttribute('api-key', 'API_KEY')
 
     const ready = new Promise<void>(resolve => {
       mojMap.addEventListener('map:ready', () => resolve(), { once: true })
@@ -94,6 +98,7 @@ describe('MojMap', () => {
     mojMap.setAttribute('tile-url', 'https://attr-tiles')
     mojMap.setAttribute('vector-url', 'https://attr-vector')
     mojMap.setAttribute('access-token-url', 'none')
+    mojMap.setAttribute('api-key', 'API_KEY')
 
     const ready = new Promise<void>(resolve => {
       mojMap.addEventListener('map:ready', () => resolve(), { once: true })
@@ -103,10 +108,11 @@ describe('MojMap', () => {
     await ready
 
     expect(setupMapLibreMap).toHaveBeenCalledTimes(1)
-    const [container, vectorUrl, enable3D] = (setupMapLibreMap as jest.Mock).mock.calls[0]
+    const [container, vectorUrl, enable3D, apiKey] = (setupMapLibreMap as jest.Mock).mock.calls[0]
     expect(container instanceof HTMLElement).toBe(true)
     expect(vectorUrl).toBe('https://attr-vector')
     expect(typeof enable3D).toBe('boolean')
+    expect(apiKey).toBe('API_KEY')
   })
 
   it('fires map:ready and exposes .map', async () => {
@@ -116,6 +122,7 @@ describe('MojMap', () => {
     mojMap.setAttribute('tile-url', 'https://attr-tiles')
     mojMap.setAttribute('vector-url', 'https://attr-vector')
     mojMap.setAttribute('access-token-url', 'none')
+    mojMap.setAttribute('api-key', 'API_KEY')
 
     const ready = new Promise<unknown>(resolve => {
       mojMap.addEventListener('map:ready', e => resolve((e as CustomEvent).detail.map), { once: true })
@@ -130,13 +137,12 @@ describe('MojMap', () => {
 
   it('addLayer attaches via adapter, and removeLayer detaches', async () => {
     const mojMap = document.createElement('moj-map') as MojMap
-
-    // Use OpenLayers Library
     mojMap.setAttribute('renderer', 'openlayers')
     mojMap.setAttribute('tile-type', 'vector')
     mojMap.setAttribute('tile-url', 'https://attr-tiles')
     mojMap.setAttribute('vector-url', 'https://attr-vector')
     mojMap.setAttribute('access-token-url', 'none')
+    mojMap.setAttribute('api-key', 'API_KEY')
 
     await new Promise<void>(resolve => {
       mojMap.addEventListener('map:ready', () => resolve(), { once: true })

--- a/src/scripts/moj-map.ts
+++ b/src/scripts/moj-map.ts
@@ -30,6 +30,8 @@ type MojMapOptions = {
   apiKey?: string
 }
 
+type OLMapInstanceWithOverlay = OLMapInstance & { featureOverlay?: FeatureOverlay }
+
 export class MojMap extends HTMLElement {
   private mapNonce: string | null = null
 
@@ -126,9 +128,7 @@ export class MojMap extends HTMLElement {
     if ((tileType ?? 'vector') === 'vector') {
       const hasKeyInUrl = /\bkey=/.test(vectorUrl)
       if (!apiKey && !hasKeyInUrl) {
-        throw new Error(
-          '[moj-map] Vector mode requires either {{mojMap apiKey: "..."> or a vector-url that already includes ?key=...',
-        )
+        console.warn('[moj-map] No apiKey and vectorUrl has no key – will fall back to raster tiles.')
       }
     }
 
@@ -183,6 +183,8 @@ export class MojMap extends HTMLElement {
         controls: this.getControlOptions(),
       })
       this.adapter = createOpenLayersAdapter(this, this.mapInstance as import('ol/Map').default)
+      const withOverlay: OLMapInstanceWithOverlay = this.mapInstance as OLMapInstanceWithOverlay
+      this.featureOverlay = withOverlay.featureOverlay
     }
   }
 


### PR DESCRIPTION
- Use passed in apiKey from consuming app rather than .env
- Handle signed url, append key to unsigned url or localhost stub for Cypress testing within an app
- Fix for sub layers not being found in Cypress tests by their title