### PR TITLE
Refactor the remaining layers to be built from position data

### DIFF
--- a/src/sandbox/fixtures/positions.json
+++ b/src/sandbox/fixtures/positions.json
@@ -2,36 +2,43 @@
     {
         "latitude": 53.4808,
         "longitude": -2.2426,
-        "precision": 50
+        "precision": 50,
+        "sequenceNumber": 1
     },
     {
         "latitude": 53.478,
         "longitude": -2.25,
-        "precision": 400
+        "precision": 400,
+        "sequenceNumber": 2
     },
     {
         "latitude": 53.483,
         "longitude": -2.236,
-        "precision": 200
+        "precision": 200,
+        "sequenceNumber": 3
     },
     {
         "latitude": 53.476,
         "longitude": -2.229,
-        "precision": 500
+        "precision": 500,
+        "sequenceNumber": 4
     },
     {
         "latitude": 53.485,
         "longitude": -2.26,
-        "precision": 300
+        "precision": 300,
+        "sequenceNumber": 5
     },
     {
         "latitude": 53.472,
         "longitude": -2.245,
-        "precision": 100
+        "precision": 100,
+        "sequenceNumber": 6
     },
     {
         "latitude": 53.49,
         "longitude": -2.255,
-        "precision": 100
+        "precision": 100,
+        "sequenceNumber": 7
     }
 ]

--- a/src/sandbox/fixtures/positions.json
+++ b/src/sandbox/fixtures/positions.json
@@ -1,30 +1,37 @@
 [
     {
         "latitude": 53.4808,
-        "longitude": -2.2426
+        "longitude": -2.2426,
+        "precision": 50
     },
     {
         "latitude": 53.478,
-        "longitude": -2.25
+        "longitude": -2.25,
+        "precision": 400
     },
     {
         "latitude": 53.483,
-        "longitude": -2.236
+        "longitude": -2.236,
+        "precision": 200
     },
     {
         "latitude": 53.476,
-        "longitude": -2.229
+        "longitude": -2.229,
+        "precision": 500
     },
     {
         "latitude": 53.485,
-        "longitude": -2.26
+        "longitude": -2.26,
+        "precision": 300
     },
     {
         "latitude": 53.472,
-        "longitude": -2.245
+        "longitude": -2.245,
+        "precision": 100
     },
     {
         "latitude": 53.49,
-        "longitude": -2.255
+        "longitude": -2.255,
+        "precision": 100
     }
 ]

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -111,7 +111,7 @@ map.addEventListener('map:ready', () => {
 
   mojMap.addLayer(
     new NumberingLayer({
-      geoJson,
+      positions,
       numberProperty: 'sequenceNumber',
       title: 'numberingLayer',
       visible: true,

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -120,10 +120,9 @@ map.addEventListener('map:ready', () => {
 
   mojMap.addLayer(
     new CirclesLayer({
-      geoJson,
+      positions,
       id: 'confidence',
       title: 'confidenceLayer',
-      radiusProperty: 'precision',
       visible: true,
     }),
   )

--- a/src/scripts/map/features/circle.ts
+++ b/src/scripts/map/features/circle.ts
@@ -1,0 +1,16 @@
+import { Feature } from 'ol'
+import { Circle } from 'ol/geom'
+import { fromLonLat } from 'ol/proj'
+import Position from '../types/position'
+
+const createCircleFeatureFromPosition = (position: Position): Feature<Circle> => {
+  return new Feature({
+    geometry: new Circle(fromLonLat([position.longitude, position.latitude]), position.precision),
+  })
+}
+
+const createCircleFeatureCollectionFromPositions = (positions: Array<Position>): Array<Feature<Circle>> => {
+  return positions.map(createCircleFeatureFromPosition)
+}
+
+export { createCircleFeatureFromPosition, createCircleFeatureCollectionFromPositions }

--- a/src/scripts/map/features/point.ts
+++ b/src/scripts/map/features/point.ts
@@ -6,6 +6,7 @@ import Position from '../types/position'
 const createPointFeatureFromPosition = (position: Position): Feature<Point> => {
   return new Feature({
     geometry: new Point(fromLonLat([position.longitude, position.latitude])),
+    ...position,
   })
 }
 

--- a/src/scripts/map/layers/circles-layer.test.ts
+++ b/src/scripts/map/layers/circles-layer.test.ts
@@ -2,12 +2,12 @@ import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
 import { Style } from 'ol/style'
 import type Feature from 'ol/Feature'
-import type { Circle as CircleGeom } from 'ol/geom'
+import type { Circle } from 'ol/geom'
 import { CirclesLayer } from './circles-layer'
 import makeOpenLayersAdapter from '../../../../tests/utils/openlayers-adapter'
 import positions from '../../../../tests/fixtures/positions'
 
-type OLCircleFeature = Feature<CircleGeom>
+type OLCircleFeature = Feature<Circle>
 type OLVecSource = VectorSource<OLCircleFeature>
 type OLVecLayer = VectorLayer<OLVecSource>
 

--- a/src/scripts/map/layers/circles-layer.test.ts
+++ b/src/scripts/map/layers/circles-layer.test.ts
@@ -1,4 +1,3 @@
-import type { FeatureCollection } from 'geojson'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
 import { Style } from 'ol/style'
@@ -6,26 +5,11 @@ import type Feature from 'ol/Feature'
 import type { Circle as CircleGeom } from 'ol/geom'
 import { CirclesLayer } from './circles-layer'
 import makeOpenLayersAdapter from '../../../../tests/utils/openlayers-adapter'
+import positions from '../../../../tests/fixtures/positions'
 
 type OLCircleFeature = Feature<CircleGeom>
 type OLVecSource = VectorSource<OLCircleFeature>
 type OLVecLayer = VectorLayer<OLVecSource>
-
-const sampleGeoJson: FeatureCollection = {
-  type: 'FeatureCollection',
-  features: [
-    {
-      type: 'Feature',
-      geometry: { type: 'Point', coordinates: [0, 0] },
-      properties: { confidence: 100 },
-    },
-    {
-      type: 'Feature',
-      geometry: { type: 'Point', coordinates: [10, 10] },
-      properties: { confidence: 200 },
-    },
-  ],
-}
 
 describe('CirclesLayer (OpenLayers library)', () => {
   beforeEach(() => {
@@ -34,7 +18,7 @@ describe('CirclesLayer (OpenLayers library)', () => {
 
   it('attaches a VectorLayer with circle features from points', () => {
     const { adapter, olMapMock } = makeOpenLayersAdapter()
-    const layer = new CirclesLayer({ geoJson: sampleGeoJson, id: 'circles' })
+    const layer = new CirclesLayer({ positions, id: 'circles' })
 
     layer.attach(adapter)
 
@@ -43,7 +27,7 @@ describe('CirclesLayer (OpenLayers library)', () => {
     expect(added).toBeInstanceOf(VectorLayer)
 
     const source = added.getSource() as OLVecSource
-    expect(source.getFeatures().length).toBe(2)
+    expect(source.getFeatures().length).toBe(6)
 
     const geomTypes = source.getFeatures().map(f => f.getGeometry()?.getType())
     expect(geomTypes.every(t => t === 'Circle')).toBe(true)
@@ -51,7 +35,7 @@ describe('CirclesLayer (OpenLayers library)', () => {
 
   it('respects visible=false and zIndex from options', () => {
     const { adapter, olMapMock } = makeOpenLayersAdapter()
-    const layer = new CirclesLayer({ geoJson: sampleGeoJson, visible: false, zIndex: 99 })
+    const layer = new CirclesLayer({ positions, visible: false, zIndex: 99 })
 
     layer.attach(adapter)
 
@@ -61,22 +45,25 @@ describe('CirclesLayer (OpenLayers library)', () => {
   })
 
   it('applies custom style when provided', () => {
-    const customStyle = new Style({})
+    const customStyle = { fill: '#fff', stroke: { color: '#000', width: 1 } }
     const { adapter, olMapMock } = makeOpenLayersAdapter()
     const layer = new CirclesLayer({
-      geoJson: sampleGeoJson,
+      positions,
       style: customStyle,
     })
 
     layer.attach(adapter)
 
     const added = olMapMock.addLayer.mock.calls[0][0] as OLVecLayer
-    expect(added.getStyle()).toBe(customStyle)
+    const style = added.getStyle() as Style
+    expect(style.getFill()?.getColor()).toBe('#fff')
+    expect(style.getStroke()?.getColor()).toBe('#000')
+    expect(style.getStroke()?.getWidth()).toBe(1)
   })
 
   it('detaches by removing the same VectorLayer', () => {
     const { adapter, olMapMock } = makeOpenLayersAdapter()
-    const layer = new CirclesLayer({ geoJson: sampleGeoJson })
+    const layer = new CirclesLayer({ positions })
 
     layer.attach(adapter)
     const added = olMapMock.addLayer.mock.calls[0][0] as OLVecLayer

--- a/src/scripts/map/layers/circles-layer.ts
+++ b/src/scripts/map/layers/circles-layer.ts
@@ -1,13 +1,12 @@
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
-import { GeoJSON } from 'ol/format'
-import { Fill, Stroke, Style } from 'ol/style'
-import { Circle as CircleGeom, Point } from 'ol/geom'
+import { Circle as CircleGeom } from 'ol/geom'
 import Feature from 'ol/Feature'
 
-import type { FeatureCollection } from 'geojson'
 import type { ComposableLayer } from './base'
 import type { MapAdapter } from '../map-adapter'
+import { OLCirclesLayer } from './ol/circles-layer'
+import Position from '../types/position'
 
 type OLCircleFeature = Feature<CircleGeom>
 type OLVecSource = VectorSource<OLCircleFeature>
@@ -18,38 +17,12 @@ export type CirclesLayerOptions = {
   title?: string
   visible?: boolean
   zIndex?: number
-  style?: Style
-  radiusProperty?: string
-  geoJson: FeatureCollection
-}
-
-const defaultStyle = new Style({
-  stroke: new Stroke({
-    color: 'orange',
-    width: 2,
-  }),
-  fill: new Fill({
-    color: 'rgba(255, 165, 0, 0.1)',
-  }),
-})
-
-function toOlSource(geoJson: FeatureCollection, radiusProperty: string): OLVecSource {
-  const formatter = new GeoJSON()
-  const pointFeatures = formatter.readFeatures(geoJson, {
-    dataProjection: 'EPSG:4326',
-    featureProjection: 'EPSG:3857',
-  }) as Array<Feature<Point>>
-
-  const circleFeatures = pointFeatures.map(feature => {
-    const geom = feature.getGeometry() as Point
-    const coords = geom.getCoordinates()
-    const radius = feature.get(radiusProperty)
-    const circle = new CircleGeom(coords, radius)
-
-    return new Feature({ geometry: circle }) as OLCircleFeature
-  })
-
-  return new VectorSource<OLCircleFeature>({ features: circleFeatures })
+  style?: {
+    fill: string
+    stroke: { color: string; width: number }
+  }
+  // The data to render (required)
+  positions: Array<Position>
 }
 
 export class CirclesLayer implements ComposableLayer<OLVecLayer> {
@@ -75,22 +48,16 @@ export class CirclesLayer implements ComposableLayer<OLVecLayer> {
     }
 
     const { map } = adapter.openlayers!
-    const radiusProp = this.options.radiusProperty ?? 'confidence'
 
-    const vectorLayer = new VectorLayer({
-      source: toOlSource(this.options.geoJson, radiusProp),
-      style: this.options.style ?? defaultStyle,
-      properties: { title: this.options.title ?? this.id },
-    }) as OLVecLayer
+    this.olLayer = new OLCirclesLayer({
+      positions: this.options.positions,
+      style: this.options.style,
+      title: this.options.title ?? this.id,
+      visible: this.options.visible,
+      zIndex: this.options.zIndex,
+    })
 
-    const resolvedVisible = this.options.visible ?? false
-    const resolvedZIndex = this.options.zIndex
-
-    vectorLayer.setVisible(resolvedVisible)
-    if (resolvedZIndex !== undefined) vectorLayer.setZIndex(resolvedZIndex)
-
-    map.addLayer(vectorLayer)
-    this.olLayer = vectorLayer
+    map.addLayer(this.olLayer)
   }
 
   detach(adapter: MapAdapter): void {

--- a/src/scripts/map/layers/circles-layer.ts
+++ b/src/scripts/map/layers/circles-layer.ts
@@ -1,6 +1,6 @@
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
-import { Circle as CircleGeom } from 'ol/geom'
+import { Circle } from 'ol/geom'
 import Feature from 'ol/Feature'
 
 import type { ComposableLayer } from './base'
@@ -8,7 +8,7 @@ import type { MapAdapter } from '../map-adapter'
 import { OLCirclesLayer } from './ol/circles-layer'
 import Position from '../types/position'
 
-type OLCircleFeature = Feature<CircleGeom>
+type OLCircleFeature = Feature<Circle>
 type OLVecSource = VectorSource<OLCircleFeature>
 type OLVecLayer = VectorLayer<OLVecSource>
 

--- a/src/scripts/map/layers/lines-layer.test.ts
+++ b/src/scripts/map/layers/lines-layer.test.ts
@@ -1,37 +1,12 @@
-import type { FeatureCollection } from 'geojson'
 import VectorLayer from 'ol/layer/Vector'
 import { LinesLayer } from './lines-layer'
 import makeOpenLayersAdapter from '../../../../tests/utils/openlayers-adapter'
+import positions from '../../../../tests/fixtures/positions'
 
 describe('LinesLayer', () => {
-  const sampleGeoJson: FeatureCollection = {
-    type: 'FeatureCollection',
-    features: [
-      {
-        type: 'Feature',
-        geometry: {
-          type: 'LineString',
-          coordinates: [
-            [0, 0],
-            [1, 1],
-          ],
-        },
-        properties: {},
-      },
-      {
-        type: 'Feature',
-        geometry: {
-          type: 'Point',
-          coordinates: [0, 0],
-        },
-        properties: {},
-      },
-    ],
-  }
-
   it('attaches and adds a VectorLayer to the map', () => {
     const { adapter, olMapMock } = makeOpenLayersAdapter()
-    const layer = new LinesLayer({ geoJson: sampleGeoJson })
+    const layer = new LinesLayer({ positions })
 
     layer.attach(adapter)
 
@@ -44,7 +19,7 @@ describe('LinesLayer', () => {
   it('respects visible and zIndex options', () => {
     const { adapter } = makeOpenLayersAdapter()
     const layer = new LinesLayer({
-      geoJson: sampleGeoJson,
+      positions,
       visible: false,
       zIndex: 5,
     })
@@ -59,7 +34,7 @@ describe('LinesLayer', () => {
   it('layerStateOptions override constructor options', () => {
     const { adapter } = makeOpenLayersAdapter()
     const layer = new LinesLayer({
-      geoJson: sampleGeoJson,
+      positions,
       visible: true,
       zIndex: 2,
     })
@@ -73,7 +48,7 @@ describe('LinesLayer', () => {
 
   it('detaches and removes the layer from the map', () => {
     const { adapter, olMapMock } = makeOpenLayersAdapter()
-    const layer = new LinesLayer({ geoJson: sampleGeoJson })
+    const layer = new LinesLayer({ positions })
     layer.attach(adapter)
 
     layer.detach(adapter)

--- a/src/scripts/map/layers/lines-layer.ts
+++ b/src/scripts/map/layers/lines-layer.ts
@@ -1,12 +1,11 @@
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
-import { GeoJSON } from 'ol/format'
-import { Stroke, Style } from 'ol/style'
 import type Feature from 'ol/Feature'
 import type { LineString } from 'ol/geom'
-import type { FeatureCollection } from 'geojson'
 import type { ComposableLayer, LayerStateOptions } from './base'
 import type { MapAdapter } from '../map-adapter'
+import { OLLinesLayer } from './ol/lines-layer'
+import Position from '../types/position'
 
 type OLLineFeature = Feature<LineString>
 type OLVecSource = VectorSource<OLLineFeature>
@@ -18,49 +17,21 @@ export type LinesLayerOptions = {
   visible?: boolean
   zIndex?: number
   style?: {
-    width?: number
-    color?: string
+    stroke: {
+      color: string
+    }
   }
-}
-
-export type LinesLayerConstructorOptions = LinesLayerOptions & {
-  geoJson: FeatureCollection
-}
-
-function buildOlStyle(style?: LinesLayerOptions['style']) {
-  return new Style({
-    stroke: new Stroke({
-      width: style?.width ?? 2,
-      color: style?.color ?? 'black',
-    }),
-  })
-}
-
-function filterToLineFeatures(geoJson: FeatureCollection): FeatureCollection {
-  return {
-    type: 'FeatureCollection',
-    features: geoJson.features.filter(f => f.geometry?.type === 'LineString'),
-  }
-}
-
-function toOlSource(geoJson: FeatureCollection): OLVecSource {
-  const onlyLines = filterToLineFeatures(geoJson)
-  const formatter = new GeoJSON()
-  const features = formatter.readFeatures(onlyLines, {
-    dataProjection: 'EPSG:4326',
-    featureProjection: 'EPSG:3857',
-  }) as OLLineFeature[]
-  return new VectorSource<OLLineFeature>({ features })
+  positions: Array<Position>
 }
 
 export class LinesLayer implements ComposableLayer<OLVecLayer> {
   public readonly id: string
 
-  private readonly options: LinesLayerConstructorOptions
+  private readonly options: LinesLayerOptions
 
   private olLayer?: OLVecLayer
 
-  constructor(options: LinesLayerConstructorOptions) {
+  constructor(options: LinesLayerOptions) {
     this.options = options
     this.id = options.id ?? 'lines'
   }
@@ -76,20 +47,16 @@ export class LinesLayer implements ComposableLayer<OLVecLayer> {
     }
 
     const { map } = adapter.openlayers!
-    const layer = new VectorLayer({
-      source: toOlSource(this.options.geoJson),
-      style: buildOlStyle(this.options.style),
-      properties: { title: this.options.title ?? this.id },
-    }) as OLVecLayer
 
-    const resolvedVisible = layerStateOptions?.visible ?? this.options.visible ?? true
-    const resolvedZIndex = layerStateOptions?.zIndex ?? this.options.zIndex
+    this.olLayer = new OLLinesLayer({
+      positions: this.options.positions,
+      style: this.options.style,
+      title: this.options.title ?? this.id,
+      visible: layerStateOptions?.visible ?? this.options.visible,
+      zIndex: layerStateOptions?.zIndex ?? this.options.zIndex,
+    })
 
-    layer.setVisible(resolvedVisible)
-    if (resolvedZIndex !== undefined) layer.setZIndex(resolvedZIndex)
-
-    map.addLayer(layer)
-    this.olLayer = layer
+    map.addLayer(this.olLayer)
   }
 
   detach(adapter: MapAdapter): void {

--- a/src/scripts/map/layers/numbering-layer.test.ts
+++ b/src/scripts/map/layers/numbering-layer.test.ts
@@ -1,4 +1,3 @@
-import type { FeatureCollection } from 'geojson'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
 import { Style, Text } from 'ol/style'
@@ -6,25 +5,10 @@ import type Feature from 'ol/Feature'
 import type Geometry from 'ol/geom/Geometry'
 import { NumberingLayer } from './numbering-layer'
 import makeOpenLayersAdapter from '../../../../tests/utils/openlayers-adapter'
+import positions from '../../../../tests/fixtures/positions'
 
 type OLVecSource = VectorSource<Feature<Geometry>>
 type OLVecLayer = VectorLayer<OLVecSource>
-
-const sampleGeoJson: FeatureCollection = {
-  type: 'FeatureCollection',
-  features: [
-    {
-      type: 'Feature',
-      geometry: { type: 'Point', coordinates: [0, 0] },
-      properties: { sequenceNumber: 1 },
-    },
-    {
-      type: 'Feature',
-      geometry: { type: 'Point', coordinates: [10, 10] },
-      properties: { sequenceNumber: 2 },
-    },
-  ],
-}
 
 describe('NumberingLayer (OpenLayers library)', () => {
   beforeEach(() => {
@@ -33,7 +17,7 @@ describe('NumberingLayer (OpenLayers library)', () => {
 
   it('attaches a VectorLayer with text styles from the numberProperty', () => {
     const { adapter, olMapMock } = makeOpenLayersAdapter()
-    const layer = new NumberingLayer({ geoJson: sampleGeoJson, id: 'numbering' })
+    const layer = new NumberingLayer({ positions, id: 'numbering' })
 
     layer.attach(adapter)
 
@@ -42,19 +26,19 @@ describe('NumberingLayer (OpenLayers library)', () => {
     expect(added).toBeInstanceOf(VectorLayer)
 
     const source = added.getSource() as OLVecSource
-    expect(source.getFeatures().length).toBe(2)
+    expect(source.getFeatures().length).toBe(6)
 
-    const styleFn = added.getStyle() as (f: Feature<Geometry>) => Style | undefined
+    const styleFn = added.getStyle() as (f: Feature<Geometry>) => Array<Style>
     const first = source.getFeatures()[0]
     const style = styleFn(first)!
-    expect(style).toBeInstanceOf(Style)
-    expect(style.getText()).toBeInstanceOf(Text)
-    expect(style.getText()?.getText()).toBe('1')
+    expect(style[0]).toBeInstanceOf(Style)
+    expect(style[0].getText()).toBeInstanceOf(Text)
+    expect(style[0].getText()?.getText()).toBe('0')
   })
 
   it('respects visible=false and zIndex from options', () => {
     const { adapter, olMapMock } = makeOpenLayersAdapter()
-    const layer = new NumberingLayer({ geoJson: sampleGeoJson, visible: false, zIndex: 42 })
+    const layer = new NumberingLayer({ positions, visible: false, zIndex: 42 })
 
     layer.attach(adapter)
 
@@ -64,25 +48,23 @@ describe('NumberingLayer (OpenLayers library)', () => {
   })
 
   it('uses custom numberProperty when provided', () => {
-    const customGeoJson: FeatureCollection = {
-      type: 'FeatureCollection',
-      features: [{ type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: { label: 'A' } }],
-    }
+    const customPositions = [{ latitude: 0, longitude: 0, precision: 0, sequenceNumber: 0, label: 'A' }]
+
     const { adapter, olMapMock } = makeOpenLayersAdapter()
-    const layer = new NumberingLayer({ geoJson: customGeoJson, numberProperty: 'label' })
+    const layer = new NumberingLayer({ positions: customPositions, numberProperty: 'label' })
 
     layer.attach(adapter)
 
     const added = olMapMock.addLayer.mock.calls[0][0] as OLVecLayer
     const source = added.getSource() as OLVecSource
-    const styleFn = added.getStyle() as (f: Feature<Geometry>) => Style | undefined
+    const styleFn = added.getStyle() as (f: Feature<Geometry>) => Array<Style>
     const style = styleFn(source.getFeatures()[0])!
-    expect(style.getText()?.getText()).toBe('A')
+    expect(style[0].getText()?.getText()).toBe('A')
   })
 
   it('detaches by removing the same VectorLayer from the map', () => {
     const { adapter, olMapMock } = makeOpenLayersAdapter()
-    const layer = new NumberingLayer({ geoJson: sampleGeoJson })
+    const layer = new NumberingLayer({ positions })
 
     layer.attach(adapter)
     const added = olMapMock.addLayer.mock.calls[0][0] as OLVecLayer

--- a/src/scripts/map/layers/ol/circles-layer.test.ts
+++ b/src/scripts/map/layers/ol/circles-layer.test.ts
@@ -1,0 +1,71 @@
+import { Style } from 'ol/style'
+import { Circle } from 'ol/geom'
+import { Feature } from 'ol'
+import { OLCirclesLayer } from './circles-layer'
+import positions from '../../../../../tests/fixtures/positions'
+
+describe('OLCirclesLayer (OpenLayers library)', () => {
+  it('should display a single circle using the precision as radius for each position', () => {
+    const layer = new OLCirclesLayer({
+      positions,
+      title: '',
+    })
+    const source = layer.getSource()
+    const features = source?.getFeatures() || []
+
+    expect(features).toHaveLength(6)
+    expect(features.map(feature => (feature as Feature<Circle>).getGeometry()?.getRadius())).toEqual([
+      100, 400, 25, 10, 0, 20,
+    ])
+  })
+
+  it('should use the default style by default', () => {
+    const layer = new OLCirclesLayer({
+      positions,
+      title: '',
+    })
+    const style = layer.getStyle() as Style
+
+    expect(style.getFill()?.getColor()).toBe('rgba(255, 165, 0, 0.1)')
+    expect(style.getStroke()?.getColor()).toBe('orange')
+    expect(style.getStroke()?.getWidth()).toBe(2)
+  })
+
+  it('should override the default style settings', () => {
+    const layer = new OLCirclesLayer({
+      positions,
+      style: {
+        fill: '#fff',
+        stroke: {
+          color: '#000',
+          width: 1,
+        },
+      },
+      title: '',
+    })
+    const style = layer.getStyle() as Style
+
+    expect(style.getFill()?.getColor()).toBe('#fff')
+    expect(style.getStroke()?.getColor()).toBe('#000')
+    expect(style.getStroke()?.getWidth()).toBe(1)
+  })
+
+  it('should be hidden by default', () => {
+    const layer = new OLCirclesLayer({
+      positions,
+      title: '',
+    })
+
+    expect(layer.getVisible()).toBeFalsy()
+  })
+
+  it('should override the default visibility', () => {
+    const layer = new OLCirclesLayer({
+      positions,
+      title: '',
+      visible: true,
+    })
+
+    expect(layer.getVisible()).toBeTruthy()
+  })
+})

--- a/src/scripts/map/layers/ol/circles-layer.ts
+++ b/src/scripts/map/layers/ol/circles-layer.ts
@@ -1,0 +1,63 @@
+import { Feature } from 'ol'
+import { Circle } from 'ol/geom'
+import VectorLayer from 'ol/layer/Vector'
+import VectorSource from 'ol/source/Vector'
+import { Fill, Stroke, Style } from 'ol/style'
+import Position from '../../types/position'
+import { createCircleFeatureCollectionFromPositions } from '../../features/circle'
+
+type OLCirclesLayerStyle = {
+  fill: string
+  stroke: {
+    color: string
+    width: number
+  }
+}
+
+type OLCirclesLayerOptions = {
+  positions: Array<Position>
+  style?: OLCirclesLayerStyle
+  title: string
+  visible?: boolean
+  zIndex?: number
+}
+
+const DEFAULT_FILL = 'rgba(255, 165, 0, 0.1)'
+const DEFAULT_STROKE_COLOR = 'orange'
+const DEFAULT_STROKE_WIDTH = 2
+const DEFAULT_VISIBILITY = false
+const DEFAULT_STYLE: OLCirclesLayerStyle = {
+  fill: DEFAULT_FILL,
+  stroke: {
+    color: DEFAULT_STROKE_COLOR,
+    width: DEFAULT_STROKE_WIDTH,
+  },
+}
+
+export class OLCirclesLayer extends VectorLayer<VectorSource<Feature<Circle>>> {
+  constructor({
+    positions,
+    style = DEFAULT_STYLE,
+    title,
+    visible = DEFAULT_VISIBILITY,
+    zIndex,
+  }: OLCirclesLayerOptions) {
+    super({
+      properties: {
+        title,
+      },
+      source: new VectorSource({
+        features: createCircleFeatureCollectionFromPositions(positions),
+      }),
+      style: new Style({
+        fill: new Fill({ color: style.fill }),
+        stroke: new Stroke({
+          color: style.stroke.color,
+          width: style.stroke.width,
+        }),
+      }),
+      visible,
+      zIndex,
+    })
+  }
+}

--- a/src/scripts/map/layers/ol/lines-layer.test.ts
+++ b/src/scripts/map/layers/ol/lines-layer.test.ts
@@ -1,0 +1,90 @@
+import { Style } from 'ol/style'
+import LineStyle from '../../styles/line'
+import { OLLinesLayer } from './lines-layer'
+import positions from '../../../../../tests/fixtures/positions'
+
+describe('OLTracksLayer (OpenLayers library)', () => {
+  it('should display a single thin line for each line segment when the resolution is large', () => {
+    const resolution = 1500
+    const layer = new OLLinesLayer({ positions, title: '' })
+    const source = layer.getSource()
+    const features = source?.getFeatures() || []
+    const styleFunction = layer.getStyleFunction()!
+    const featureStyles = features.map(feature => styleFunction(feature, resolution)) as Array<Style>
+
+    expect(featureStyles).toHaveLength(5)
+    expect(featureStyles[0]).toBeInstanceOf(LineStyle)
+    expect(featureStyles[0].getStroke()?.getWidth()).toBe(1.25)
+    expect(featureStyles[1]).toBeInstanceOf(LineStyle)
+    expect(featureStyles[1].getStroke()?.getWidth()).toBe(1.25)
+    expect(featureStyles[2]).toBeInstanceOf(LineStyle)
+    expect(featureStyles[2].getStroke()?.getWidth()).toBe(1.25)
+    expect(featureStyles[3]).toBeInstanceOf(LineStyle)
+    expect(featureStyles[3].getStroke()?.getWidth()).toBe(1.25)
+    expect(featureStyles[4]).toBeInstanceOf(LineStyle)
+    expect(featureStyles[4].getStroke()?.getWidth()).toBe(1.25)
+  })
+
+  it('should display a single line and one or more arrows for each line segment when the resolution is small', () => {
+    const resolution = 0.15
+    const layer = new OLLinesLayer({ positions, title: '' })
+    const source = layer.getSource()
+    const features = source?.getFeatures() || []
+    const styleFunction = layer.getStyleFunction()!
+    const featureStyles = features.map(feature => styleFunction(feature, resolution)) as Array<Style>
+
+    expect(featureStyles).toHaveLength(5)
+    expect(featureStyles[0]).toBeInstanceOf(LineStyle)
+    expect(featureStyles[0].getStroke()?.getWidth()).toBe(2)
+    expect(featureStyles[0].getStroke()?.getColor()).toBe('black')
+    expect(featureStyles[1]).toBeInstanceOf(LineStyle)
+    expect(featureStyles[1].getStroke()?.getWidth()).toBe(2)
+    expect(featureStyles[1].getStroke()?.getColor()).toBe('black')
+    expect(featureStyles[2]).toBeInstanceOf(LineStyle)
+    expect(featureStyles[2].getStroke()?.getWidth()).toBe(2)
+    expect(featureStyles[2].getStroke()?.getColor()).toBe('black')
+    expect(featureStyles[3]).toBeInstanceOf(LineStyle)
+    expect(featureStyles[3].getStroke()?.getWidth()).toBe(2)
+    expect(featureStyles[3].getStroke()?.getColor()).toBe('black')
+    expect(featureStyles[4]).toBeInstanceOf(LineStyle)
+    expect(featureStyles[4].getStroke()?.getWidth()).toBe(2)
+    expect(featureStyles[4].getStroke()?.getColor()).toBe('black')
+  })
+
+  it('should override the default style settings', () => {
+    const layer = new OLLinesLayer({
+      positions,
+      style: {
+        stroke: {
+          color: 'red',
+        },
+      },
+      title: '',
+    })
+    const source = layer.getSource()
+    const features = source?.getFeatures() || []
+    const styleFunction = layer.getStyleFunction()!
+    const style = styleFunction(features[0], 0) as Style
+
+    expect(style.getStroke()?.getColor()).toBe('red')
+  })
+
+  it('should be hidden by default', () => {
+    const layer = new OLLinesLayer({
+      positions,
+      title: '',
+    })
+
+    expect(layer.getVisible()).toBeFalsy()
+  })
+
+  it('should override the default visibility', () => {
+    const layer = new OLLinesLayer({
+      positions,
+      title: '',
+      visible: true,
+    })
+
+    expect(layer.getVisible()).toBeTruthy()
+  })
+})

--- a/src/scripts/map/layers/ol/lines-layer.test.ts
+++ b/src/scripts/map/layers/ol/lines-layer.test.ts
@@ -3,7 +3,7 @@ import LineStyle from '../../styles/line'
 import { OLLinesLayer } from './lines-layer'
 import positions from '../../../../../tests/fixtures/positions'
 
-describe('OLTracksLayer (OpenLayers library)', () => {
+describe('OLLinesLayer (OpenLayers library)', () => {
   it('should display a single thin line for each line segment when the resolution is large', () => {
     const resolution = 1500
     const layer = new OLLinesLayer({ positions, title: '' })

--- a/src/scripts/map/layers/ol/lines-layer.ts
+++ b/src/scripts/map/layers/ol/lines-layer.ts
@@ -1,0 +1,50 @@
+import VectorLayer from 'ol/layer/Vector'
+import VectorSource from 'ol/source/Vector'
+import Feature, { FeatureLike } from 'ol/Feature'
+import { Style } from 'ol/style'
+import { LineString } from 'ol/geom'
+import LineStyle from '../../styles/line'
+import { createLineStringFeatureCollectionFromPositions } from '../../features/line-string'
+import Position from '../../types/position'
+
+type OLLinesLayerStyle = {
+  stroke: {
+    color: string
+  }
+}
+
+type OLLinesLayerOptions = {
+  positions: Array<Position>
+  style?: OLLinesLayerStyle
+  title: string
+  visible?: boolean
+  zIndex?: number
+}
+
+const createStyleFunction =
+  (style: OLLinesLayerStyle) =>
+  (_: FeatureLike, resolution: number): Style => {
+    return new LineStyle(style.stroke.color, resolution)
+  }
+
+const DEFAULT_VISIBILITY = false
+const DEFAULT_STROKE_COLOR = 'black'
+const DEFAULT_STYLE: OLLinesLayerStyle = {
+  stroke: {
+    color: DEFAULT_STROKE_COLOR,
+  },
+}
+
+export class OLLinesLayer extends VectorLayer<VectorSource<Feature<LineString>>> {
+  constructor({ positions, style = DEFAULT_STYLE, title, visible = DEFAULT_VISIBILITY, zIndex }: OLLinesLayerOptions) {
+    super({
+      properties: {
+        title,
+      },
+      source: new VectorSource({ features: createLineStringFeatureCollectionFromPositions(positions) }),
+      style: createStyleFunction(style),
+      visible,
+      zIndex,
+    })
+  }
+}

--- a/src/scripts/map/layers/ol/numbering-layer.test.ts
+++ b/src/scripts/map/layers/ol/numbering-layer.test.ts
@@ -1,0 +1,122 @@
+import { Style } from 'ol/style'
+import { OLNumberingLayer } from './numbering-layer'
+import positions from '../../../../../tests/fixtures/positions'
+
+describe('OLNumberingLayer (OpenLayers library)', () => {
+  it('should display a single text style for each position', () => {
+    const layer = new OLNumberingLayer({
+      positions,
+      title: '',
+    })
+    const source = layer.getSource()
+    const features = source?.getFeatures() || []
+    const styleFunction = layer.getStyleFunction()!
+    const featureStyles = features.map(feature => styleFunction(feature, 0)) as Array<Array<Style>>
+
+    expect(featureStyles).toHaveLength(6)
+    expect(featureStyles[0]).toHaveLength(1)
+    expect(featureStyles[0][0].getText()?.getText()).toBe('0')
+    expect(featureStyles).toHaveLength(6)
+    expect(featureStyles[1]).toHaveLength(1)
+    expect(featureStyles[1][0].getText()?.getText()).toBe('1')
+    expect(featureStyles).toHaveLength(6)
+    expect(featureStyles[2]).toHaveLength(1)
+    expect(featureStyles[2][0].getText()?.getText()).toBe('2')
+    expect(featureStyles).toHaveLength(6)
+    expect(featureStyles[3]).toHaveLength(1)
+    expect(featureStyles[3][0].getText()?.getText()).toBe('3')
+    expect(featureStyles).toHaveLength(6)
+    expect(featureStyles[4]).toHaveLength(1)
+    expect(featureStyles[4][0].getText()?.getText()).toBe('4')
+    expect(featureStyles).toHaveLength(6)
+    expect(featureStyles[5]).toHaveLength(1)
+    expect(featureStyles[5][0].getText()?.getText()).toBe('5')
+  })
+
+  it('should not display a style if the numbering property is undefined', () => {
+    const layer = new OLNumberingLayer({
+      numberProperty: 'unknown',
+      positions,
+      title: '',
+    })
+    const source = layer.getSource()
+    const features = source?.getFeatures() || []
+    const styleFunction = layer.getStyleFunction()!
+    const featureStyles = features.map(feature => styleFunction(feature, 0)) as Array<Array<Style>>
+
+    expect(featureStyles).toHaveLength(6)
+    expect(featureStyles[0]).toHaveLength(0)
+    expect(featureStyles[1]).toHaveLength(0)
+    expect(featureStyles[2]).toHaveLength(0)
+    expect(featureStyles[3]).toHaveLength(0)
+    expect(featureStyles[4]).toHaveLength(0)
+    expect(featureStyles[5]).toHaveLength(0)
+  })
+
+  it('should use the default style by default', () => {
+    const layer = new OLNumberingLayer({
+      positions,
+      title: '',
+    })
+    const source = layer.getSource()
+    const features = source?.getFeatures() || []
+    const styleFunction = layer.getStyleFunction()!
+    const style = styleFunction(features[0], 0) as Array<Style>
+
+    expect(style[0].getText()?.getFill()?.getColor()).toBe('black')
+    expect(style[0].getText()?.getStroke()?.getColor()).toBe('white')
+    expect(style[0].getText()?.getStroke()?.getWidth()).toBe(2)
+    expect(style[0].getText()?.getOffsetX()).toBe(12)
+    expect(style[0].getText()?.getOffsetY()).toBe(1)
+    expect(style[0].getText()?.getFont()).toBe('bold 14px "GDS Transport", system-ui, sans-serif')
+  })
+
+  it('should override the default style settings', () => {
+    const layer = new OLNumberingLayer({
+      positions,
+      style: {
+        fill: '#fff',
+        font: 'sans-serif',
+        offset: {
+          x: 20,
+          y: 10,
+        },
+        stroke: {
+          color: '#000',
+          width: 1,
+        },
+      },
+      title: '',
+    })
+    const source = layer.getSource()
+    const features = source?.getFeatures() || []
+    const styleFunction = layer.getStyleFunction()!
+    const style = styleFunction(features[0], 0) as Array<Style>
+
+    expect(style[0].getText()?.getFill()?.getColor()).toBe('#fff')
+    expect(style[0].getText()?.getStroke()?.getColor()).toBe('#000')
+    expect(style[0].getText()?.getStroke()?.getWidth()).toBe(1)
+    expect(style[0].getText()?.getOffsetX()).toBe(20)
+    expect(style[0].getText()?.getOffsetY()).toBe(10)
+    expect(style[0].getText()?.getFont()).toBe('sans-serif')
+  })
+
+  it('should be hidden by default', () => {
+    const layer = new OLNumberingLayer({
+      positions,
+      title: '',
+    })
+
+    expect(layer.getVisible()).toBeFalsy()
+  })
+
+  it('should override the default visibility', () => {
+    const layer = new OLNumberingLayer({
+      positions,
+      title: '',
+      visible: true,
+    })
+
+    expect(layer.getVisible()).toBeTruthy()
+  })
+})

--- a/src/scripts/map/layers/ol/numbering-layer.ts
+++ b/src/scripts/map/layers/ol/numbering-layer.ts
@@ -1,0 +1,104 @@
+import Position from '@scripts/map/types/position'
+import { Feature } from 'ol'
+import { Point } from 'ol/geom'
+import VectorLayer from 'ol/layer/Vector'
+import VectorSource from 'ol/source/Vector'
+import { Fill, Stroke, Style, Text } from 'ol/style'
+import { FeatureLike } from 'ol/Feature'
+import { createPointFeatureCollectionFromPositions } from '../../features/point'
+
+type OLNumberingLayerStyle = {
+  fill: string
+  font: string
+  offset: {
+    x: number
+    y: number
+  }
+  stroke: {
+    color: string
+    width: number
+  }
+}
+
+type OLNumberingLayerOptions = {
+  numberProperty?: string
+  positions: Array<Position>
+  style?: OLNumberingLayerStyle
+  title: string
+  visible?: boolean
+  zIndex?: number
+}
+
+const DEFAULT_NUMBER_PROPERTY = 'sequenceNumber'
+const DEFAULT_FONT = 'bold 14px "GDS Transport", system-ui, sans-serif'
+const DEFAULT_FILL = 'black'
+const DEFAULT_STROKE_COLOR = 'white'
+const DEFAULT_STROKE_WIDTH = 2
+const DEFAULT_OFFSET_X = 12
+const DEFAULT_OFFSET_Y = 1
+const DEFAULT_VISIBILITY = false
+const DEFAULT_STYLE: OLNumberingLayerStyle = {
+  fill: DEFAULT_FILL,
+  font: DEFAULT_FONT,
+  offset: {
+    x: DEFAULT_OFFSET_X,
+    y: DEFAULT_OFFSET_Y,
+  },
+  stroke: {
+    color: DEFAULT_STROKE_COLOR,
+    width: DEFAULT_STROKE_WIDTH,
+  },
+}
+
+const createStyleFunction =
+  (style: OLNumberingLayerStyle, property: string) =>
+  (feature: FeatureLike): Array<Style> => {
+    const value = feature.get(property)
+
+    console.log(feature)
+
+    if (value !== undefined) {
+      return [
+        new Style({
+          text: new Text({
+            textAlign: 'left',
+            textBaseline: 'middle',
+            font: style.font,
+            fill: new Fill({ color: style.fill }),
+            stroke: new Stroke({
+              color: style.stroke.color,
+              width: style.stroke.width,
+            }),
+            text: String(feature.get(property)),
+            offsetX: style.offset.x,
+            offsetY: style.offset.y,
+          }),
+        }),
+      ]
+    }
+
+    return []
+  }
+
+export class OLNumberingLayer extends VectorLayer<VectorSource<Feature<Point>>> {
+  constructor({
+    numberProperty = DEFAULT_NUMBER_PROPERTY,
+    positions,
+    style = DEFAULT_STYLE,
+    title,
+    visible = DEFAULT_VISIBILITY,
+    zIndex,
+  }: OLNumberingLayerOptions) {
+    super({
+      properties: {
+        title,
+      },
+      source: new VectorSource({
+        features: createPointFeatureCollectionFromPositions(positions),
+      }),
+      style: createStyleFunction(style, numberProperty),
+      visible,
+      zIndex,
+    })
+  }
+}

--- a/src/scripts/map/layers/ol/numbering-layer.ts
+++ b/src/scripts/map/layers/ol/numbering-layer.ts
@@ -55,8 +55,6 @@ const createStyleFunction =
   (feature: FeatureLike): Array<Style> => {
     const value = feature.get(property)
 
-    console.log(feature)
-
     if (value !== undefined) {
       return [
         new Style({

--- a/src/scripts/map/layers/ol/tracks-layer.test.ts
+++ b/src/scripts/map/layers/ol/tracks-layer.test.ts
@@ -7,7 +7,7 @@ import positions from '../../../../../tests/fixtures/positions'
 describe('OLTracksLayer (OpenLayers library)', () => {
   it('should display a single line and arrow for each line segment when the resolution is large', () => {
     const resolution = 1500
-    const layer = new OLTracksLayer(positions, '', true, 1)
+    const layer = new OLTracksLayer({ positions, title: '' })
     const source = layer.getSource()
     const features = source?.getFeatures() || []
     const styleFunction = layer.getStyleFunction()!
@@ -16,6 +16,8 @@ describe('OLTracksLayer (OpenLayers library)', () => {
     expect(featureStyles).toHaveLength(5)
     expect(featureStyles[0]).toHaveLength(2)
     expect(featureStyles[0][0]).toBeInstanceOf(LineStyle)
+    expect(featureStyles[0][0].getStroke()?.getWidth()).toBe(1.25)
+    expect(featureStyles[0][0].getStroke()?.getColor()).toBe('black')
     expect(featureStyles[0][1]).toBeInstanceOf(ArrowStyle)
     expect(featureStyles[1]).toHaveLength(2)
     expect(featureStyles[1][0]).toBeInstanceOf(LineStyle)
@@ -33,7 +35,7 @@ describe('OLTracksLayer (OpenLayers library)', () => {
 
   it('should display a single line and one or more arrows for each line segment when the resolution is small', () => {
     const resolution = 3
-    const layer = new OLTracksLayer(positions, '', true, 1)
+    const layer = new OLTracksLayer({ positions, title: '' })
     const source = layer.getSource()
     const features = source?.getFeatures() || []
     const styleFunction = layer.getStyleFunction()!
@@ -42,6 +44,8 @@ describe('OLTracksLayer (OpenLayers library)', () => {
     expect(featureStyles).toHaveLength(5)
     expect(featureStyles[0]).toHaveLength(3)
     expect(featureStyles[0][0]).toBeInstanceOf(LineStyle)
+    expect(featureStyles[0][0].getStroke()?.getWidth()).toBeCloseTo(1.78)
+    expect(featureStyles[0][0].getStroke()?.getColor()).toBe('black')
     expect(featureStyles[0][1]).toBeInstanceOf(ArrowStyle)
     expect(featureStyles[0][2]).toBeInstanceOf(ArrowStyle)
     expect(featureStyles[1]).toHaveLength(6)
@@ -64,15 +68,40 @@ describe('OLTracksLayer (OpenLayers library)', () => {
     expect(featureStyles[4][2]).toBeInstanceOf(ArrowStyle)
   })
 
-  it('should make the layer visible', () => {
-    const layer = new OLTracksLayer(positions, '', true, 1)
+  it('should override the default style settings', () => {
+    const layer = new OLTracksLayer({
+      positions,
+      style: {
+        stroke: {
+          color: 'red',
+        },
+      },
+      title: '',
+    })
+    const source = layer.getSource()
+    const features = source?.getFeatures() || []
+    const styleFunction = layer.getStyleFunction()!
+    const style = styleFunction(features[0], 1) as Array<Style>
 
-    expect(layer.getVisible()).toBeTruthy()
+    expect(style[0].getStroke()?.getColor()).toBe('red')
   })
 
-  it('should make the layer hidden', () => {
-    const layer = new OLTracksLayer(positions, '', false, 1)
+  it('should be hidden by default', () => {
+    const layer = new OLTracksLayer({
+      positions,
+      title: '',
+    })
 
     expect(layer.getVisible()).toBeFalsy()
+  })
+
+  it('should override the default visibility', () => {
+    const layer = new OLTracksLayer({
+      positions,
+      title: '',
+      visible: true,
+    })
+
+    expect(layer.getVisible()).toBeTruthy()
   })
 })

--- a/src/scripts/map/layers/tracks-layer.ts
+++ b/src/scripts/map/layers/tracks-layer.ts
@@ -54,8 +54,7 @@ export class TracksLayer implements ComposableLayer<OLVecLayer> {
       title: this.options.title ?? this.id,
       visible: this.options.visible,
       zIndex: this.options.zIndex,
-    }
-    )
+    })
 
     map.addLayer(this.olLayer)
   }

--- a/src/scripts/map/layers/tracks-layer.ts
+++ b/src/scripts/map/layers/tracks-layer.ts
@@ -15,6 +15,11 @@ export type TracksLayerOptions = {
   title?: string
   visible?: boolean
   zIndex?: number
+  style?: {
+    stroke: {
+      color: string
+    }
+  }
   // The data to render (required)
   positions: Array<Position>
 }
@@ -43,11 +48,13 @@ export class TracksLayer implements ComposableLayer<OLVecLayer> {
 
     const { map } = adapter.openlayers!
 
-    this.olLayer = new OLTracksLayer(
-      this.options.positions,
-      this.options.title ?? this.id,
-      this.options.visible ?? false,
-      this.options.zIndex,
+    this.olLayer = new OLTracksLayer({
+      positions: this.options.positions,
+      style: this.options.style,
+      title: this.options.title ?? this.id,
+      visible: this.options.visible,
+      zIndex: this.options.zIndex,
+    }
     )
 
     map.addLayer(this.olLayer)

--- a/src/scripts/map/styles/line.ts
+++ b/src/scripts/map/styles/line.ts
@@ -15,11 +15,11 @@ const scaleLineWidthWithResolution = (resolution: number): number => {
 }
 
 class LineStyle extends Style {
-  constructor(resolution: number) {
+  constructor(strokeColor: string, resolution: number) {
     super({
       stroke: new Stroke({
         width: scaleLineWidthWithResolution(resolution),
-        color: 'black',
+        color: strokeColor,
       }),
     })
   }

--- a/src/scripts/map/types/position.ts
+++ b/src/scripts/map/types/position.ts
@@ -2,6 +2,7 @@ type Position = {
   latitude: number
   longitude: number
   precision: number
+  sequenceNumber: number
 }
 
 export default Position

--- a/src/scripts/map/types/position.ts
+++ b/src/scripts/map/types/position.ts
@@ -1,6 +1,7 @@
 type Position = {
   latitude: number
   longitude: number
+  precision: number
 }
 
 export default Position

--- a/tests/fixtures/positions.ts
+++ b/tests/fixtures/positions.ts
@@ -2,26 +2,32 @@ const positions = [
   {
     latitude: 51.574865,
     longitude: 0.060977,
+    precision: 100,
   },
   {
     latitude: 51.574153,
     longitude: 0.058536,
+    precision: 400,
   },
   {
     latitude: 51.573248244162706,
     longitude: 0.05111371418603764,
+    precision: 25,
   },
   {
     latitude: 51.574622,
     longitude: 0.048643,
+    precision: 10,
   },
   {
     latitude: 51.57610341773559,
     longitude: 0.048391168020475,
+    precision: 0,
   },
   {
     latitude: 51.576400900843375,
     longitude: 0.045439341454295505,
+    precision: 20,
   },
 ]
 

--- a/tests/fixtures/positions.ts
+++ b/tests/fixtures/positions.ts
@@ -3,31 +3,37 @@ const positions = [
     latitude: 51.574865,
     longitude: 0.060977,
     precision: 100,
+    sequenceNumber: 0,
   },
   {
     latitude: 51.574153,
     longitude: 0.058536,
     precision: 400,
+    sequenceNumber: 1,
   },
   {
     latitude: 51.573248244162706,
     longitude: 0.05111371418603764,
     precision: 25,
+    sequenceNumber: 2,
   },
   {
     latitude: 51.574622,
     longitude: 0.048643,
     precision: 10,
+    sequenceNumber: 3,
   },
   {
     latitude: 51.57610341773559,
     longitude: 0.048391168020475,
     precision: 0,
+    sequenceNumber: 4,
   },
   {
     latitude: 51.576400900843375,
     longitude: 0.045439341454295505,
     precision: 20,
+    sequenceNumber: 5,
   },
 ]
 


### PR DESCRIPTION
All open layers implementations share a common pattern so I've updated the tracks layer to conform.

Fixed a minor bug in the numbering layer where a value of `0` was being treated as false (e.g. `if(value) <render> else <dont>`).
