### PR TITLE
Added getNativeLayer and setLayerVisibility methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-  "version": "0.2.5-beta.1",
+  "version": "0.2.6-beta.1",
   "description": "HMPPS Electronic Monitoring Frontend Components",
   "repository": {
     "type": "git",

--- a/src/components/map/scripts/em-map.ts
+++ b/src/components/map/scripts/em-map.ts
@@ -217,8 +217,27 @@ export class EmMap extends HTMLElement {
     return this.layers.get(id)
   }
 
+  public getNativeLayer(idOrTitle: string): BaseLayer | undefined {
+    return this.findNativeLayersByIdOrTitle(idOrTitle)[0]
+  }
+
   public closeOverlay() {
     this.featureOverlay?.close()
+  }
+
+  public setLayerVisibility(idOrTitle: string, visible: boolean): void {
+    // Try composable layer first
+    const composable = this.getLayer(idOrTitle)
+    if (composable) {
+      composable.getPrimaryLayer().setVisible(visible)
+      return
+    }
+
+    // Fallback to native layers/groups
+    const native = this.getNativeLayer(idOrTitle)
+    if (native) {
+      native.setVisible(visible)
+    }
   }
 
   // Fits the map view to the given targets (layers or points), with options for padding, max zoom, and animation.

--- a/src/stories/map/layers-docs.mdx
+++ b/src/stories/map/layers-docs.mdx
@@ -169,7 +169,7 @@ const group = new LayerGroup({
 emMap.addLayerGroup(group)
 ```
 
-### Accessing the underlying OpenLayers layers
+### Accessing the underlying OpenLayers layers from a composable layer
 
 Composable layers provide `getLayers()` to return their native OpenLayers layers.
 
@@ -182,6 +182,40 @@ const primaryLayer = locationsLayer.getPrimaryLayer()
 primaryLayer.setVisible(false)
 primaryLayer.setZIndex(10)
 ```
+
+### Accessing native OpenLayers layers
+
+If you need full OpenLayers control, you can access the underlying layer by passing the id or title:
+
+```ts
+const layer = emMap.getNativeLayer('analysisNumberingGroup')
+
+layer?.setVisible(false)
+layer?.setZIndex(10)
+```
+
+This returns:
+
+- a native VectorLayer, WebGLVectorLayer, etc.
+- or a LayerGroup
+
+## Controlling visibility (layers and groups)
+
+You can control visibility of both composable layers and native OpenLayers layers (including LayerGroups) using the map API.
+
+### Simple visibility control
+
+```ts
+emMap.setLayerVisibility('tracks', false)
+emMap.setLayerVisibility('analysisNumberingGroup', true)
+```
+
+This works for:
+
+- composable layers (LocationsLayer, TracksLayer, etc.)
+- native OpenLayers layers
+- native OpenLayers LayerGroups
+- nested groups
 
 ---
 


### PR DESCRIPTION
Should be able to use specific OL methods

```ts
const layer = emMap.getNativeLayer('analysisNumberingGroup')

layer?.setVisible(false)
layer?.setZIndex(10)
```

or just for visibility, the below will handle all layer types, composable, native or layer groups

```ts
emMap.setLayerVisibility('tracks', false)
emMap.setLayerVisibility('analysisNumberingGroup', true)
```

