### PR TITLE
ACR-688 Adding ability to copy values from overlay rows via a copy link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-  "version": "v0.2.8-beta.1",
+  "version": "0.2.9-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-      "version": "v0.2.8-beta.1",
+      "version": "0.2.9-beta.1",
       "license": "MIT",
       "dependencies": {
         "@types/qs": "^6.9.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-  "version": "v0.2.8-beta.1",
+  "version": "0.2.9-beta.1",
   "description": "HMPPS Electronic Monitoring Frontend Components",
   "repository": {
     "type": "git",

--- a/src/components/map/scripts/core/overlays/feature-overlay.ts
+++ b/src/components/map/scripts/core/overlays/feature-overlay.ts
@@ -68,10 +68,40 @@ export default class FeatureOverlay extends Overlay {
       console.warn(`[FeatureOverlay] No valid template found for overlayBodyTemplateId="${bodyTemplateId}"`)
     }
 
+    this.attachCopyHandlers()
+
     this.container.hidden = false
     this.setPosition(coordinate)
 
     this.container.dispatchEvent(new CustomEvent('map:overlay:open', { bubbles: true }))
+  }
+
+  private attachCopyHandlers() {
+    const copyLinks = this.content.querySelectorAll<HTMLAnchorElement>('.app-map__copy-link')
+
+    copyLinks.forEach(link => {
+      const el = link
+
+      if (el.dataset.copyBound === 'true') return
+      el.dataset.copyBound = 'true'
+
+      el.addEventListener('click', async event => {
+        event.preventDefault()
+
+        const row = el.closest('.app-map__overlay-row')
+        if (!row) return
+
+        const valueEl = row.querySelector<HTMLElement>('[data-copy-value]')
+        const valueToCopy = valueEl?.dataset.copyValue
+        if (!valueToCopy) return
+
+        try {
+          await navigator.clipboard.writeText(valueToCopy)
+        } catch (err) {
+          console.error('[FeatureOverlay] Copy failed', err)
+        }
+      })
+    })
   }
 
   close() {


### PR DESCRIPTION
Added `attachCopyHandlers()` to the FeatureOverlay which scans the overlay for copy links, attaches click handlers and copies a value associated with the clicked row to the clipboard using the Clipboard API.

Example usage:

```
<div class="app-map__overlay-row app-map__overlay-row--location">
        <span class="app-map__overlay-label">Location:</span>

        <span
          class="app-map__overlay-value app-map__overlay-value--with-action"
          data-copy-value="{{ longitude }}, {{ latitude }}">
          
          <span class="app-map__overlay-text">
            {{ longitude }}, {{ latitude }}
          </span>

          <a
            href="#"
            class="app-map__copy-link"
            aria-label="Copy location">
            Copy
          </a>
        </span>
</div>
```
