### PR TITLE
Refine position type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-  "version": "0.2.9-beta.1",
+  "version": "0.2.10-beta.1",
   "description": "HMPPS Electronic Monitoring Frontend Components",
   "repository": {
     "type": "git",

--- a/src/components/map/scripts/core/features/circle.ts
+++ b/src/components/map/scripts/core/features/circle.ts
@@ -1,18 +1,17 @@
 import { Feature } from 'ol'
 import Polygon, { circular as circularPolygon } from 'ol/geom/Polygon'
-import { PositionWithPrecision } from '../types/position'
+import { Position } from '../types/position'
 
-const createCircleFeatureFromPosition = (position: PositionWithPrecision): Feature<Polygon> => {
+const createCircleFeatureFromPosition = (position: Position): Feature<Polygon> => {
   const center = [position.longitude, position.latitude]
   const circle = circularPolygon(center, position.precision, 64).transform('EPSG:4326', 'EPSG:3857')
+
   return new Feature({
     geometry: circle,
   })
 }
 
-const createCircleFeatureCollectionFromPositions = (
-  positions: Array<PositionWithPrecision>,
-): Array<Feature<Polygon>> => {
+const createCircleFeatureCollectionFromPositions = (positions: Array<Position>): Array<Feature<Polygon>> => {
   return positions.map(createCircleFeatureFromPosition)
 }
 

--- a/src/components/map/scripts/core/layers/circles-layer.ts
+++ b/src/components/map/scripts/core/layers/circles-layer.ts
@@ -2,7 +2,7 @@ import BaseLayer from 'ol/layer/Base'
 import type { ComposableLayer, LayerStateOptions } from './base'
 import type { MapAdapter } from '../map-adapter'
 import { OLCirclesLayer } from './ol/circles-layer'
-import type { Position, PositionWithPrecision } from '../types/position'
+import type { Position } from '../types/position'
 
 export type CirclesLayerOptions = {
   id?: string
@@ -24,10 +24,6 @@ export type CirclesLayerOptions = {
   positions?: Array<Position>
 }
 
-function hasPrecision(position: Position): position is PositionWithPrecision {
-  return 'precision' in position && typeof position.precision === 'number'
-}
-
 export class CirclesLayer implements ComposableLayer<BaseLayer[]> {
   public readonly id: string
 
@@ -41,12 +37,9 @@ export class CirclesLayer implements ComposableLayer<BaseLayer[]> {
   }
 
   private createLayers(): BaseLayer[] {
-    const allPositions = this.options.positions ?? []
-    const precisePositions = allPositions.filter(hasPrecision)
-
     return [
       new OLCirclesLayer({
-        positions: precisePositions,
+        positions: this.options.positions,
         style: this.options.style,
         title: this.options.title ?? this.id,
         visible: this.options.visible,

--- a/src/components/map/scripts/core/layers/ol/circles-layer.ts
+++ b/src/components/map/scripts/core/layers/ol/circles-layer.ts
@@ -3,7 +3,7 @@ import { Polygon } from 'ol/geom'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
 import { Fill, Stroke, Style } from 'ol/style'
-import { PositionWithPrecision } from '../../types/position'
+import { Position } from '../../types/position'
 import { createCircleFeatureCollectionFromPositions } from '../../features/circle'
 
 type OLCirclesLayerStyle = {
@@ -20,7 +20,7 @@ type OLCirclesLayerStyle = {
 }
 
 type OLCirclesLayerOptions = {
-  positions?: Array<PositionWithPrecision>
+  positions?: Array<Position>
   style?: OLCirclesLayerStyle
   title: string
   visible?: boolean

--- a/src/components/map/scripts/core/types/position.ts
+++ b/src/components/map/scripts/core/types/position.ts
@@ -23,7 +23,7 @@ type Position = {
       }
   >
 
-  /** Short label for display in overlays. */
+  /** Optional short label for display in overlays. */
   label?: string
 
   /** Optional map marker configuration. */

--- a/src/components/map/scripts/core/types/position.ts
+++ b/src/components/map/scripts/core/types/position.ts
@@ -1,6 +1,23 @@
 import type { MarkerOptions } from '../layers/locations-layer'
 
 /**
+ * Displayable property value for a position.
+ *
+ * Can be a simple string, or an object that separates the displayed value
+ * from the value used when copying (e.g. formatted vs raw).
+ */
+type Property =
+  /** Simple display value. */
+  | string
+  | {
+      /** Value shown in the UI. */
+      value: string
+
+      /** Value used when copied. */
+      copyValue: string
+    }
+
+/**
  * Geographic position associated with a Crime or Electronic Monitoring device.
  */
 type Position = {
@@ -14,14 +31,7 @@ type Position = {
   precision: number
 
   /** Optional metadata for display in overlays. */
-  properties?: Record<
-    string,
-    | string
-    | {
-        value: string
-        copyValue: string
-      }
-  >
+  properties?: Record<string, Property>
 
   /** Optional short label for display in overlays. */
   label?: string
@@ -30,4 +40,4 @@ type Position = {
   marker?: MarkerOptions
 }
 
-export type { Position }
+export type { Position, Property }

--- a/src/components/map/scripts/core/types/position.ts
+++ b/src/components/map/scripts/core/types/position.ts
@@ -1,13 +1,33 @@
 import type { MarkerOptions } from '../layers/locations-layer'
 
+/**
+ * Geographic position associated with a Crime or Electronic Monitoring device.
+ */
 type Position = {
+  /** Latitude in decimal degrees (WGS84). */
   latitude: number
+
+  /** Longitude in decimal degrees (WGS84). */
   longitude: number
+
+  /** Position accuracy in metres. */
+  precision: number
+
+  /** Optional metadata for display in overlays. */
+  properties?: Record<
+    string,
+    | string
+    | {
+        value: string
+        copyValue: string
+      }
+  >
+
+  /** Short label for display in overlays. */
+  label?: string
+
+  /** Optional map marker configuration. */
   marker?: MarkerOptions
 }
 
-type PositionWithPrecision = Position & {
-  precision: number
-}
-
-export type { Position, PositionWithPrecision }
+export type { Position }

--- a/src/components/map/scripts/index.ts
+++ b/src/components/map/scripts/index.ts
@@ -3,3 +3,5 @@
 import './global'
 
 export { EmMap } from './em-map'
+
+export type { Position, Property } from './core/types/position'

--- a/src/stories/map/viewport-example.stories.ts
+++ b/src/stories/map/viewport-example.stories.ts
@@ -133,7 +133,7 @@ const meta: Meta = {
 
         case 'focusOn':
           map.focusOn({
-            center: { latitude: 53.48, longitude: -2.24 },
+            center: { latitude: 53.48, longitude: -2.24, precision: 0 },
             zoom: 12,
             ...animationOpts,
           })


### PR DESCRIPTION
## Refine `Position` type
All Position types share 3 attributes, latitude, longitude, precision. The `precision` value for an Electronic Monitoring device position is a measure of the uncertainty of the GPS recording, in the same way, the `precision` of a crime (by default 100m) is a measure of the uncertainty in the recording of the crime. Its possible that there may be additional properties e.g. speed / altitude but we haven't had to use those yet and don't receive them from crime data so I'm going to ignore them, although we could add sensible defaults for crime data.
 
All Positions, be that a crime or a tag position have additional metadata. For example, an electronic monitoring position have some additional properties e.g. device id  and crimes might have additional properties e.g. crime ref. These properties are ONLY used for display purposes (e.g. in overlays) are not used in plotting positions on a map.

## Export `Position` type and `Property` type

We're currently having to define `Position` in the UI repository. The definition doesn't always align. As the various map layers expect `Position` of this format, we should expose the types to make constructing map data easier.

## Documentation 
- Added jsdoc style documentation for types so consuming projects get useful IDE hints.
