### PR TITLE
Updating styling of overlay copy link functionality

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -65,11 +65,11 @@
   <div class="app-map__overlay-row">
     <span class="app-map__overlay-label">Latitude</span>
     <span class="app-map__overlay-value" data-copy-value="51.5761">
-      <span class="app-map__overlay-text">51.5761</span>
-      <a href="#" class="app-map__copy-link" aria-label="Copy latitude">
-        Copy
-      </a>
+      <span class="app-map__overlay-text">51.5761,</span>
     </span>
+    <a href="#" class="app-map__copy-link" aria-label="Copy latitude">
+      Copy
+    </a>
   </div>
   <div class="app-map__overlay-row">
     <span class="app-map__overlay-label">Longitude </span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-  "version": "0.2.9-beta.1",
+  "version": "0.2.12-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-      "version": "0.2.9-beta.1",
+      "version": "0.2.12-beta.1",
       "license": "MIT",
       "dependencies": {
         "@types/qs": "^6.9.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-  "version": "0.2.11-beta.1",
+  "version": "0.2.12-beta.1",
   "description": "HMPPS Electronic Monitoring Frontend Components",
   "repository": {
     "type": "git",

--- a/src/components/map/styles/_overlay.scss
+++ b/src/components/map/styles/_overlay.scss
@@ -102,8 +102,8 @@
 
 .app-map__overlay-label,
 :host::part(app-map__overlay-label) {
-  flex: 0 0 50%;
-  max-width: 50%;
+  flex: 0 0 40%;
+  max-width: 40%;
   overflow-wrap: break-word;
   word-break: break-word;
   text-align: left;


### PR DESCRIPTION
Styling of the copy link was incorrect, these changes better match the designs
<img width="563" height="337" alt="image" src="https://github.com/user-attachments/assets/22bca646-759d-4db3-a33e-9c3d0b7594b8" />