### PR TITLE
Toggle zoom controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-  "version": "0.2.14-beta.1",
+  "version": "0.2.15-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-      "version": "0.2.14-beta.1",
+      "version": "0.2.15-beta.1",
       "license": "MIT",
       "dependencies": {
         "@types/qs": "^6.9.18",
@@ -16749,9 +16749,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.5",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.5.tgz",
-      "integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
+      "version": "5.31.6",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
+      "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-  "version": "0.2.15-beta.1",
+  "version": "0.2.16-beta.1",
   "description": "HMPPS Electronic Monitoring Frontend Components",
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
     "vite": "vite",
     "build:css": "set -e; for file in src/components/**/styles/[!_]*.scss; do sass --no-source-map --quiet-deps --load-path=node_modules \"$file\" \"${file%.scss}.raw.css\"; done",
     "watch:css": "chokidar --glob \"src/components/**/styles/**/*.scss\" -c \"npm run build:css --silent\"",
-    "build": "rm -rf dist && rm -rf dist && npm run build:css && vite build && tsc -p tsconfig.build.json -p tsconfig.build.json",
+    "build": "rm -rf dist && npm run build:css && vite build && tsc -p tsconfig.build.json",
     "start-feature": "npm run build:css && storybook dev -p 6006",
     "build-storybook": "npm run build:css && storybook build",
     "setup": "npm ci && hmpps-npm-script-run-allowlist"
@@ -160,7 +160,6 @@
     "qs": "^6.14.2",
     "flatted": "^3.4.1",
     "immutable": "^5.1.5",
-    "systeminformation": "^5.30.8",
     "path-to-regexp": "0.1.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "int-test": "npm run build:css && cypress run --component --config-file integration_tests/cypress.config.ts",
     "int-test:ui": "npm run build:css && cypress open --component --browser chrome --config-file integration_tests/cypress.config.ts",
     "vite": "vite",
-    "build:css": "set -e; for file in src/components/**/styles/[!_]*.scss; do sass --no-source-map --quiet-deps --load-path=node_modules \"$file\" \"${file%.scss}.raw.css\"; done",
+    "build:css": "set -e; set -e; for file in src/components/**/styles/[^_][!_]*.scss; do sass --no-source-map --quiet-deps --load-path=node_modules \"$file\" \"${file%.scss}.raw.css\"; done",
     "watch:css": "chokidar --glob \"src/components/**/styles/**/*.scss\" -c \"npm run build:css --silent\"",
-    "build": "rm -rf dist && npm run build:css && vite build && tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && rm -rf dist && npm run build:css && vite build && tsc -p tsconfig.build.json -p tsconfig.build.json",
     "start-feature": "npm run build:css && storybook dev -p 6006",
     "build-storybook": "npm run build:css && storybook build",
     "setup": "npm ci && hmpps-npm-script-run-allowlist"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "int-test": "npm run build:css && cypress run --component --config-file integration_tests/cypress.config.ts",
     "int-test:ui": "npm run build:css && cypress open --component --browser chrome --config-file integration_tests/cypress.config.ts",
     "vite": "vite",
-    "build:css": "set -e; set -e; for file in src/components/**/styles/[^_][!_]*.scss; do sass --no-source-map --quiet-deps --load-path=node_modules \"$file\" \"${file%.scss}.raw.css\"; done",
+    "build:css": "set -e; for file in src/components/**/styles/[!_]*.scss; do sass --no-source-map --quiet-deps --load-path=node_modules \"$file\" \"${file%.scss}.raw.css\"; done",
     "watch:css": "chokidar --glob \"src/components/**/styles/**/*.scss\" -c \"npm run build:css --silent\"",
     "build": "rm -rf dist && rm -rf dist && npm run build:css && vite build && tsc -p tsconfig.build.json -p tsconfig.build.json",
     "start-feature": "npm run build:css && storybook dev -p 6006",

--- a/src/components/map/scripts/core/open-layers-map-instance.test.ts
+++ b/src/components/map/scripts/core/open-layers-map-instance.test.ts
@@ -85,6 +85,24 @@ describe('EmMapInstance', () => {
     expect(olControl.ZoomSlider).toHaveBeenCalled()
   })
 
+  it('enables default zoom control by default', () => {
+    new OLMapInstance({ target, controls: {} })
+
+    expect(olControl.defaults).toHaveBeenCalledWith({ rotate: false, attribution: false, zoom: true })
+  })
+
+  it('disables default zoom control when zoomControl = false', () => {
+    new OLMapInstance({ target, controls: { zoomControl: false } })
+
+    expect(olControl.defaults).toHaveBeenCalledWith({ rotate: false, attribution: false, zoom: false })
+  })
+
+  it('enables default zoom control when zoomSlider = true and zoomControl = false', () => {
+    new OLMapInstance({ target, controls: { zoomControl: false, zoomSlider: true } })
+
+    expect(olControl.defaults).toHaveBeenCalledWith({ rotate: false, attribution: false, zoom: true })
+  })
+
   it('uses DefaultView', () => {
     new OLMapInstance({ target })
     expect(defaultView.default).toHaveBeenCalled()

--- a/src/components/map/scripts/core/open-layers-map-instance.ts
+++ b/src/components/map/scripts/core/open-layers-map-instance.ts
@@ -21,6 +21,7 @@ export interface OLMapOptions {
     olRotationMode?: 'default' | 'right-drag'
     olRotateTooltip?: boolean
     zoomSlider?: boolean
+    zoomControl?: boolean
     scaleControl?: 'bar' | 'line'
     locationDisplay?: 'dms' | 'latlon'
     locationDisplaySource?: 'centre' | 'pointer'
@@ -33,7 +34,13 @@ export class OLMapInstance extends Map {
     const layers = options.layers || []
     const controlOptions = options.controls || {}
 
-    const controls = defaultControls({ rotate: false, attribution: false })
+    const zoomControl = controlOptions.zoomSlider || controlOptions.zoomControl !== false
+
+    const controls = defaultControls({
+      rotate: false,
+      attribution: false,
+      zoom: zoomControl,
+    })
 
     // Rotate control
     if (controlOptions.rotate !== false) {

--- a/src/components/map/scripts/em-map.ts
+++ b/src/components/map/scripts/em-map.ts
@@ -681,6 +681,8 @@ export class EmMap extends HTMLElement {
     const locationDisplay = (this.getAttribute('location-display') as 'dms' | 'latlon' | null) ?? undefined
     const locationDisplaySource = (this.getAttribute('location-source') as 'centre' | 'pointer' | null) ?? undefined
     const zoomSlider = parseBool('zoom-slider')
+    const zoomControl =
+      zoomSlider || !this.hasAttribute('zoom-control') || this.getAttribute('zoom-control') !== 'false'
     const grabCursor = parseBool('grab-cursor')
     let scaleControl: 'bar' | 'line' | undefined
 
@@ -706,6 +708,7 @@ export class EmMap extends HTMLElement {
     }
 
     this.classList.toggle('has-rotate-control', rotateButtonOpt !== false)
+    this.classList.toggle('has-zoom-control', zoomControl)
     this.classList.toggle('has-zoom-slider', zoomSlider)
     this.classList.toggle('has-scale-control', !!scaleControl)
     this.classList.toggle('has-location-dms', locationDisplay === 'dms')
@@ -717,6 +720,7 @@ export class EmMap extends HTMLElement {
       rotate: rotateButtonOpt,
       olRotateTooltip,
       olRotationMode,
+      zoomControl,
       zoomSlider,
       scaleControl,
       locationDisplay,

--- a/src/components/map/styles/_controls.scss
+++ b/src/components/map/styles/_controls.scss
@@ -50,7 +50,7 @@
   background-color: transparent;
   left: 0.5em;
   right: auto;
-  top: 80px;
+  top: 0;
 
   .ol-rotate-reset {
     border-radius: 50%;
@@ -91,6 +91,11 @@
     opacity: 1;
     transform: translateY(-4px);
   }
+}
+
+/* When zoom controls are present, move rotate below the controls */
+:host(.has-zoom-control) .ol-control.ol-rotate {
+  top: 80px;
 }
 
 /* When zoom slider is present, move rotate below the slider */

--- a/src/nunjucks/em-map/template.njk
+++ b/src/nunjucks/em-map/template.njk
@@ -6,6 +6,7 @@
     {% if params.apiKey %}api-key="{{ params.apiKey }}"{% endif %}
     {% if params.renderer %}renderer="{{ params.renderer }}"{% endif %}
     {% if params.controls.scaleControl %}scale-control="{{ params.controls.scaleControl }}"{% endif %}
+    {% if params.controls.zoomControl %}zoom-control{% endif %}
     {% if params.controls.zoomSlider %}zoom-slider{% endif %}
     {% if params.controls.rotateControl is defined %}
     {% if params.controls.rotateControl === 'auto-hide' %}

--- a/src/stories/map/layers-example.stories.ts
+++ b/src/stories/map/layers-example.stories.ts
@@ -50,6 +50,7 @@ const meta = {
       enable3D: args.enable3D,
       markerMode: args.markerMode,
       controls: {
+        zoomControl: true,
         zoomSlider: true,
         rotate: 'auto-hide',
         scale: 'bar',
@@ -118,6 +119,7 @@ export const Example: Story = {
     scaleControl: 'bar',
     locationDisplay: 'latlon',
     rotateControl: 'auto-hide',
+    zoomControl: true,
     zoomSlider: true
   }
 }) }}`

--- a/src/stories/map/setup-example.stories.ts
+++ b/src/stories/map/setup-example.stories.ts
@@ -7,6 +7,7 @@ type SetupStoryArgs = {
   enable3D: boolean
   positions: any[]
   usesInternalOverlays: boolean
+  'controls.zoomControl': boolean
   'controls.zoomSlider': boolean
   'controls.rotate': 'true' | 'auto-hide' | 'false'
   'controls.olRotationMode': 'default' | 'right-drag'
@@ -42,7 +43,10 @@ const meta = {
       control: 'boolean',
       description: 'Enable click-to-open overlays (injects demo templates automatically)',
     },
-
+    'controls.zoomControl': {
+      control: 'boolean',
+      table: { category: 'Controls' },
+    },
     'controls.zoomSlider': {
       control: 'boolean',
       table: { category: 'Controls' },
@@ -138,6 +142,7 @@ const meta = {
       enable3D: storyArgs.enable3D,
       usesInternalOverlays: storyArgs.usesInternalOverlays,
       controls: {
+        zoomControl: storyArgs['controls.zoomControl'],
         zoomSlider: storyArgs['controls.zoomSlider'],
         rotate: storyArgs['controls.rotate'],
         olRotationMode: storyArgs['controls.olRotationMode'],
@@ -171,6 +176,7 @@ export const Example: Story = {
     positions,
     usesInternalOverlays: true,
 
+    'controls.zoomControl': true,
     'controls.zoomSlider': false,
     'controls.rotate': 'false',
     'controls.olRotationMode': 'default',
@@ -230,6 +236,7 @@ export const Example: Story = {
     rotateControl: '${args['controls.rotate']}',
     olRotationMode: '${args['controls.olRotationMode']}',
     olRotateTooltip: ${args['controls.olRotateTooltip']},
+    zoomControl: ${args['controls.zoomControl']},
     zoomSlider: ${args['controls.zoomSlider']},
     grabCursor: ${args['controls.grabCursor']}
   }

--- a/src/stories/map/setupMapDemo.ts
+++ b/src/stories/map/setupMapDemo.ts
@@ -24,6 +24,7 @@ interface MapDemoOptions {
   renderer?: 'openlayers' | 'maplibre'
   enable3D?: boolean
   controls?: {
+    zoomControl?: boolean
     zoomSlider?: boolean
     rotate?: 'true' | 'auto-hide' | 'false'
     olRotationMode?: 'default' | 'right-drag'
@@ -196,6 +197,7 @@ export function setupMapDemo({
     rotate: 'true',
     olRotationMode: 'default',
     olRotateTooltip: true,
+    zoomControl: true,
     zoomSlider: true,
   },
   showPositions = true,
@@ -232,6 +234,7 @@ export function setupMapDemo({
   if (controls.olRotationMode) map.setAttribute('ol-rotation-mode', controls.olRotationMode)
   if (typeof controls.olRotateTooltip === 'boolean')
     map.setAttribute('ol-rotate-tooltip', String(controls.olRotateTooltip))
+  if (typeof controls.zoomControl === 'boolean') map.setAttribute('zoom-control', String(controls.zoomControl))
   if (typeof controls.zoomSlider === 'boolean') map.setAttribute('zoom-slider', String(controls.zoomSlider))
   if (typeof controls.grabCursor === 'boolean') map.setAttribute('grab-cursor', String(controls.grabCursor))
 


### PR DESCRIPTION
- Updated vulnerability in version of systeminformation that was pinned in overrides. 
- Add option to hide the zoom +- control buttons. Map users may want to not display these controls for some reason so won't do any harm offering it as an option, but primary reason for adding this is it will now allow the Proximity Alert export headless browser to only show the rotate control, when calling the map via the Nunjucks view, rather than managing it via client-side JS.