### PR TITLE
ACR-920: Support more straightforward attribution for OS Maps

### DIFF
--- a/integration_tests/component/initialisation.cy.ts
+++ b/integration_tests/component/initialisation.cy.ts
@@ -27,4 +27,20 @@ describe('<em-map> initialisation', () => {
       })
     })
   })
+
+  it('renders declarative attribution and sanitizes unsafe links', () => {
+    cy.mountEmMap({
+      attrs: {
+        'csp-nonce': 'x',
+        attribution: '<a href="https://example.test">Safe</a> <a href="javascript:alert(1)">Unsafe</a>',
+        'attribution-allow-html': '',
+      },
+    })
+    cy.wait('@stubMapStyle')
+
+    cy.get('em-map').shadow().find('.em-map__attribution').should('be.visible')
+    cy.get('em-map').shadow().find('.em-map__attribution a').should('have.length', 1)
+    cy.get('em-map').shadow().find('.em-map__attribution a').first().should('have.attr', 'href').and('include', 'https://example.test')
+    cy.get('em-map').shadow().find('.em-map__attribution').should('contain.text', 'Unsafe')
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-  "version": "0.2.20",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-      "version": "0.2.20",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@types/qs": "^6.9.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-electronic-monitoring-components",
-  "version": "0.2.20",
+  "version": "0.3.0",
   "description": "HMPPS Electronic Monitoring Frontend Components",
   "repository": {
     "type": "git",

--- a/src/components/map/scripts/core/map-adapter.test.ts
+++ b/src/components/map/scripts/core/map-adapter.test.ts
@@ -1,6 +1,6 @@
 import Map from 'ol/Map'
 import View from 'ol/View'
-import { createOpenLayersAdapter } from './map-adapter'
+import { createMapLibreAdapter, createOpenLayersAdapter } from './map-adapter'
 
 describe('createOpenLayersAdapter', () => {
   let map: Map
@@ -41,5 +41,68 @@ describe('createOpenLayersAdapter', () => {
     const roundTrip = adapter.unproject(coords)
     expect(roundTrip[0]).toBeCloseTo(lonLat[0], 6)
     expect(roundTrip[1]).toBeCloseTo(lonLat[1], 6)
+  })
+
+  it('sets plain-text attribution on the map target', () => {
+    const target = document.createElement('div')
+    const mapWithTarget = {
+      getTargetElement: jest.fn(() => target),
+    } as unknown as Map
+
+    const adapter = createOpenLayersAdapter(document.createElement('div'), mapWithTarget)
+    adapter.setAttribution('Copyright map provider')
+
+    const attribution = target.querySelector('.em-map__attribution') as HTMLElement
+    expect(attribution).toBeTruthy()
+    expect(attribution.hidden).toBe(false)
+    expect(attribution.textContent).toBe('Copyright map provider')
+  })
+
+  it('sanitizes attribution HTML to safe links only', () => {
+    const target = document.createElement('div')
+    const mapWithTarget = {
+      getTargetElement: jest.fn(() => target),
+    } as unknown as Map
+
+    const adapter = createOpenLayersAdapter(document.createElement('div'), mapWithTarget)
+    adapter.setAttribution('<strong>x</strong> <a href="ftp://example.test">bad</a>', { allowHtml: true })
+
+    const attribution = target.querySelector('.em-map__attribution') as HTMLElement
+    expect(attribution.innerHTML).toContain('x')
+    expect(attribution.innerHTML).toContain('<a>bad</a>')
+    expect(attribution.innerHTML).not.toContain('ftp:')
+  })
+
+  it('hides attribution when empty string is set', () => {
+    const target = document.createElement('div')
+    const mapWithTarget = {
+      getTargetElement: jest.fn(() => target),
+    } as unknown as Map
+
+    const adapter = createOpenLayersAdapter(document.createElement('div'), mapWithTarget)
+    adapter.setAttribution('Shown first')
+    adapter.setAttribution('   ')
+
+    const attribution = target.querySelector('.em-map__attribution') as HTMLElement
+    expect(attribution.hidden).toBe(true)
+  })
+})
+
+describe('createMapLibreAdapter', () => {
+  it('sets HTML attribution with safe https link', () => {
+    const container = document.createElement('div')
+    const map = {
+      getContainer: jest.fn(() => container),
+    } as unknown as import('maplibre-gl').Map
+
+    const adapter = createMapLibreAdapter(document.createElement('div'), map)
+    adapter.setAttribution('<a href="https://example.test">Provider</a>', { allowHtml: true })
+
+    const attribution = container.querySelector('.em-map__attribution') as HTMLElement
+    const anchor = attribution.querySelector('a') as HTMLAnchorElement
+    expect(anchor).toBeTruthy()
+    expect(anchor.getAttribute('href')).toBe('https://example.test/')
+    expect(anchor.getAttribute('target')).toBe('_blank')
+    expect(anchor.getAttribute('rel')).toBe('noopener noreferrer')
   })
 })

--- a/src/components/map/scripts/core/map-adapter.test.ts
+++ b/src/components/map/scripts/core/map-adapter.test.ts
@@ -69,7 +69,8 @@ describe('createOpenLayersAdapter', () => {
 
     const attribution = target.querySelector('.em-map__attribution') as HTMLElement
     expect(attribution.innerHTML).toContain('x')
-    expect(attribution.innerHTML).toContain('<a>bad</a>')
+    expect(attribution.textContent).toContain('bad')
+    expect(attribution.querySelector('a')).toBeNull()
     expect(attribution.innerHTML).not.toContain('ftp:')
   })
 

--- a/src/components/map/scripts/core/map-adapter.ts
+++ b/src/components/map/scripts/core/map-adapter.ts
@@ -4,6 +4,10 @@ import type { Coordinate } from 'ol/coordinate'
 
 export type MapLibrary = 'openlayers' | 'maplibre'
 
+export type AttributionOptions = {
+  allowHtml?: boolean
+}
+
 /*
   MapAdapter exposes a bridge between mapping libraries so
   layers/interactions can work without knowing which map library is used.
@@ -23,6 +27,86 @@ export interface MapAdapter {
   // Exactly one of these will be defined based on mapLibrary:
   openlayers?: { map: Map }
   mapLibre?: { map: import('maplibre-gl').Map }
+
+  // Set custom runtime attribution text/HTML for the map container.
+  setAttribution: (attribution: string, options?: AttributionOptions) => void
+}
+
+function sanitizeAttributionHtml(input: string): string {
+  const wrapper = document.createElement('div')
+  wrapper.innerHTML = input
+
+  const allElements = Array.from(wrapper.querySelectorAll('*'))
+
+  for (const element of allElements) {
+    if (element.tagName === 'A') {
+      const anchor = element as HTMLAnchorElement
+      const rawHref = anchor.getAttribute('href')?.trim() ?? ''
+      let safeHref: string | null = null
+
+      if (rawHref.length > 0) {
+        try {
+          const parsed = new URL(rawHref, window.location.origin)
+          const protocol = parsed.protocol.toLowerCase()
+          if (protocol === 'http:' || protocol === 'https:' || protocol === 'mailto:') {
+            safeHref = parsed.href
+          }
+        } catch {
+          safeHref = null
+        }
+      }
+
+      const text = anchor.textContent ?? ''
+      const replacement = document.createElement('a')
+      replacement.textContent = text
+
+      if (safeHref) {
+        replacement.setAttribute('href', safeHref)
+        replacement.setAttribute('target', '_blank')
+        replacement.setAttribute('rel', 'noopener noreferrer')
+      }
+
+      anchor.replaceWith(replacement)
+    } else {
+      const textNode = document.createTextNode(element.textContent ?? '')
+      element.replaceWith(textNode)
+    }
+  }
+
+  return wrapper.innerHTML
+}
+
+function getAttributionContainer(root: HTMLElement): HTMLElement {
+  const existing = root.querySelector('.em-map__attribution')
+  if (existing instanceof HTMLElement) return existing
+
+  const el = document.createElement('div')
+  el.className = 'em-map__attribution'
+  el.hidden = true
+  root.appendChild(el)
+  return el
+}
+
+function setContainerAttribution(
+  targetContainer: HTMLElement,
+  attribution: string,
+  options?: AttributionOptions,
+): void {
+  const container = targetContainer
+  const value = attribution.trim()
+  if (!value) {
+    container.textContent = ''
+    container.hidden = true
+    return
+  }
+
+  if (options?.allowHtml) {
+    container.innerHTML = sanitizeAttributionHtml(value)
+  } else {
+    container.textContent = value
+  }
+
+  container.hidden = false
 }
 
 // Adapter for an OpenLayers-backed map instance.
@@ -33,6 +117,13 @@ export function createOpenLayersAdapter(hostElement: HTMLElement, map: Map): Map
     project: lonLat => fromLonLat(lonLat) as [number, number],
     unproject: xy => toLonLat(xy) as [number, number],
     openlayers: { map },
+    setAttribution: (attribution, options) => {
+      const targetElement = map.getTargetElement()
+      if (!targetElement) return
+
+      const container = getAttributionContainer(targetElement)
+      setContainerAttribution(container, attribution, options)
+    },
   }
 }
 
@@ -44,5 +135,12 @@ export function createMapLibreAdapter(hostElement: HTMLElement, map: import('map
     project: lonLat => lonLat,
     unproject: xy => xy as [number, number],
     mapLibre: { map },
+    setAttribution: (attribution, options) => {
+      const targetElement = map.getContainer()
+      if (!targetElement) return
+
+      const container = getAttributionContainer(targetElement)
+      setContainerAttribution(container, attribution, options)
+    },
   }
 }

--- a/src/components/map/scripts/core/map-adapter.ts
+++ b/src/components/map/scripts/core/map-adapter.ts
@@ -57,16 +57,17 @@ function sanitizeAttributionHtml(input: string): string {
       }
 
       const text = anchor.textContent ?? ''
-      const replacement = document.createElement('a')
-      replacement.textContent = text
-
       if (safeHref) {
+        const replacement = document.createElement('a')
+        replacement.textContent = text
         replacement.setAttribute('href', safeHref)
         replacement.setAttribute('target', '_blank')
         replacement.setAttribute('rel', 'noopener noreferrer')
+        anchor.replaceWith(replacement)
+      } else {
+        const textNode = document.createTextNode(text)
+        anchor.replaceWith(textNode)
       }
-
-      anchor.replaceWith(replacement)
     } else {
       const textNode = document.createTextNode(element.textContent ?? '')
       element.replaceWith(textNode)

--- a/src/components/map/scripts/em-map.test.ts
+++ b/src/components/map/scripts/em-map.test.ts
@@ -3,6 +3,9 @@ import * as dom from './helpers/dom'
 import { setupOpenLayersMap } from './core/setup/setup-openlayers-map'
 import { setupMapLibreMap } from './core/setup/setup-maplibre-map'
 
+const mockOlTargetElement = document.createElement('div')
+const mockMapLibreContainer = document.createElement('div')
+
 jest.mock('./helpers/dom', () => ({
   createMapDOM: jest.fn(),
   createScopedStyle: jest.fn(),
@@ -33,6 +36,7 @@ jest.mock('./core/setup/setup-openlayers-map', () => {
   const mockMap = {
     getView: () => mockView,
     getSize: jest.fn(() => [800, 600]),
+    getTargetElement: jest.fn(() => mockOlTargetElement),
     getLayers: jest.fn(() => ({
       getArray: jest.fn(() => []),
     })),
@@ -45,7 +49,9 @@ jest.mock('./core/setup/setup-openlayers-map', () => {
 })
 
 jest.mock('./core/setup/setup-maplibre-map', () => ({
-  setupMapLibreMap: jest.fn().mockResolvedValue({ addLayer: jest.fn() }),
+  setupMapLibreMap: jest
+    .fn()
+    .mockResolvedValue({ addLayer: jest.fn(), getContainer: jest.fn(() => mockMapLibreContainer) }),
 }))
 
 jest.mock('maplibre-gl', () => ({
@@ -62,6 +68,8 @@ describe('EmMap', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
     jest.clearAllMocks()
+    mockOlTargetElement.innerHTML = ''
+    mockMapLibreContainer.innerHTML = ''
 
     const getMapNonceMock = dom.getMapNonce as jest.Mock
     getMapNonceMock.mockReturnValue('test-nonce')
@@ -163,7 +171,7 @@ describe('EmMap', () => {
 
     // Remove by ID
     const fakeLayerById = { id: 'test', attach, detach }
-    emMap.addLayer(fakeLayerById)
+    emMap.addLayer(fakeLayerById as any)
     expect(attach).toHaveBeenCalledTimes(1)
     expect(attach.mock.calls[0][0]).toHaveProperty('mapLibrary', 'openlayers')
 
@@ -179,7 +187,7 @@ describe('EmMap', () => {
       options: { title: 'tracksLayer' },
     }
 
-    emMap.addLayer(fakeLayerByTitle)
+    emMap.addLayer(fakeLayerByTitle as any)
     emMap.removeLayer('tracksLayer')
     expect(detach).toHaveBeenCalledTimes(2) // Called twice for ID and title
   })
@@ -284,8 +292,8 @@ describe('EmMap', () => {
         {
           type: 'points',
           points: [
-            { latitude: 0, longitude: 0 },
-            { latitude: 1, longitude: 1 },
+            { latitude: 0, longitude: 0, precision: 0 },
+            { latitude: 1, longitude: 1, precision: 0 },
           ],
         },
       ],
@@ -328,7 +336,7 @@ describe('EmMap', () => {
     const animateSpy = jest.spyOn(view, 'animate')
 
     emMap.fitTo({
-      targets: [{ type: 'points', points: [{ latitude: 1, longitude: 1 }] }],
+      targets: [{ type: 'points', points: [{ latitude: 1, longitude: 1, precision: 0 }] }],
     })
 
     expect(animateSpy).toHaveBeenCalledTimes(1)
@@ -356,8 +364,8 @@ describe('EmMap', () => {
         {
           type: 'points',
           points: [
-            { latitude: 0, longitude: 0 },
-            { latitude: 1, longitude: 1 },
+            { latitude: 0, longitude: 0, precision: 0 },
+            { latitude: 1, longitude: 1, precision: 0 },
           ],
         },
       ],
@@ -388,8 +396,8 @@ describe('EmMap', () => {
         {
           type: 'points',
           points: [
-            { latitude: 0, longitude: 0 },
-            { latitude: 1, longitude: 1 },
+            { latitude: 0, longitude: 0, precision: 0 },
+            { latitude: 1, longitude: 1, precision: 0 },
           ],
         },
       ],
@@ -447,5 +455,58 @@ describe('EmMap', () => {
     })
 
     expect(fitSpy).not.toHaveBeenCalled()
+  })
+
+  it('setAttribution applies runtime text attribution for OpenLayers', async () => {
+    const emMap = document.createElement('em-map') as EmMap
+    emMap.setAttribute('renderer', 'openlayers')
+    emMap.setAttribute('vector-url', 'https://test-vector')
+
+    await new Promise<void>(resolve => {
+      emMap.addEventListener('map:ready', () => resolve(), { once: true })
+      document.body.appendChild(emMap)
+    })
+
+    emMap.setAttribution('Map data provider')
+
+    const attribution = mockOlTargetElement.querySelector('.em-map__attribution') as HTMLElement
+    expect(attribution).toBeTruthy()
+    expect(attribution.textContent).toBe('Map data provider')
+    expect(attribution.hidden).toBe(false)
+  })
+
+  it('setAttribution queues value before map is ready', async () => {
+    const emMap = document.createElement('em-map') as EmMap
+    emMap.setAttribute('renderer', 'openlayers')
+    emMap.setAttribute('vector-url', 'https://test-vector')
+
+    emMap.setAttribution('Queued attribution')
+
+    await new Promise<void>(resolve => {
+      emMap.addEventListener('map:ready', () => resolve(), { once: true })
+      document.body.appendChild(emMap)
+    })
+
+    const attribution = mockOlTargetElement.querySelector('.em-map__attribution') as HTMLElement
+    expect(attribution.textContent).toBe('Queued attribution')
+  })
+
+  it('setAttribution allows safe hyperlink HTML for MapLibre', async () => {
+    const emMap = document.createElement('em-map') as EmMap
+    emMap.setAttribute('renderer', 'maplibre')
+    emMap.setAttribute('vector-url', 'https://test-vector')
+
+    await new Promise<void>(resolve => {
+      emMap.addEventListener('map:ready', () => resolve(), { once: true })
+      document.body.appendChild(emMap)
+    })
+
+    emMap.setAttribution('<a href="https://example.test">OS Attribution</a>', { allowHtml: true })
+
+    const attribution = mockMapLibreContainer.querySelector('.em-map__attribution') as HTMLElement
+    const anchor = attribution.querySelector('a') as HTMLAnchorElement
+    expect(anchor).toBeTruthy()
+    expect(anchor.getAttribute('href')).toBe('https://example.test/')
+    expect(anchor.textContent).toBe('OS Attribution')
   })
 })

--- a/src/components/map/scripts/em-map.test.ts
+++ b/src/components/map/scripts/em-map.test.ts
@@ -509,4 +509,73 @@ describe('EmMap', () => {
     expect(anchor.getAttribute('href')).toBe('https://example.test/')
     expect(anchor.textContent).toBe('OS Attribution')
   })
+
+  it('applies attribution from HTML attributes on initialization', async () => {
+    const emMap = document.createElement('em-map') as EmMap
+    emMap.setAttribute('renderer', 'openlayers')
+    emMap.setAttribute('vector-url', 'https://test-vector')
+    emMap.setAttribute('attribution', 'Crown copyright')
+
+    await new Promise<void>(resolve => {
+      emMap.addEventListener('map:ready', () => resolve(), { once: true })
+      document.body.appendChild(emMap)
+    })
+
+    const attribution = mockOlTargetElement.querySelector('.em-map__attribution') as HTMLElement
+    expect(attribution).toBeTruthy()
+    expect(attribution.textContent).toBe('Crown copyright')
+    expect(attribution.hidden).toBe(false)
+  })
+
+  it('applies HTML attribution from attributes when allow flag is present', async () => {
+    const emMap = document.createElement('em-map') as EmMap
+    emMap.setAttribute('renderer', 'maplibre')
+    emMap.setAttribute('vector-url', 'https://test-vector')
+    emMap.setAttribute('attribution', '<a href="https://example.test">OS Link</a>')
+    emMap.setAttribute('attribution-allow-html', '')
+
+    await new Promise<void>(resolve => {
+      emMap.addEventListener('map:ready', () => resolve(), { once: true })
+      document.body.appendChild(emMap)
+    })
+
+    const attribution = mockMapLibreContainer.querySelector('.em-map__attribution') as HTMLElement
+    const anchor = attribution.querySelector('a') as HTMLAnchorElement
+    expect(anchor).toBeTruthy()
+    expect(anchor.getAttribute('href')).toBe('https://example.test/')
+    expect(anchor.textContent).toBe('OS Link')
+  })
+
+  it('does not show attribution when only attribution-allow-html is set', async () => {
+    const emMap = document.createElement('em-map') as EmMap
+    emMap.setAttribute('renderer', 'openlayers')
+    emMap.setAttribute('vector-url', 'https://test-vector')
+    emMap.setAttribute('attribution-allow-html', '')
+
+    await new Promise<void>(resolve => {
+      emMap.addEventListener('map:ready', () => resolve(), { once: true })
+      document.body.appendChild(emMap)
+    })
+
+    const attribution = mockOlTargetElement.querySelector('.em-map__attribution')
+    expect(attribution).toBeNull()
+  })
+
+  it('treats attribution-allow-html="false" as plain text', async () => {
+    const emMap = document.createElement('em-map') as EmMap
+    emMap.setAttribute('renderer', 'openlayers')
+    emMap.setAttribute('vector-url', 'https://test-vector')
+    emMap.setAttribute('attribution', '<a href="https://example.test">OS Link</a>')
+    emMap.setAttribute('attribution-allow-html', 'false')
+
+    await new Promise<void>(resolve => {
+      emMap.addEventListener('map:ready', () => resolve(), { once: true })
+      document.body.appendChild(emMap)
+    })
+
+    const attribution = mockOlTargetElement.querySelector('.em-map__attribution') as HTMLElement
+    const anchor = attribution.querySelector('a')
+    expect(anchor).toBeNull()
+    expect(attribution.textContent).toContain('OS Link')
+  })
 })

--- a/src/components/map/scripts/em-map.ts
+++ b/src/components/map/scripts/em-map.ts
@@ -39,6 +39,7 @@ type EmMapOptions = {
   usesInternalOverlays: boolean
   overlayBodyTemplateId?: string
   overlayTitleTemplateId?: string
+  attribution?: { value: string; options?: AttributionOptions }
 }
 
 type OLMapInstanceWithOverlay = OLMapInstance & { featureOverlay?: FeatureOverlay }
@@ -555,6 +556,9 @@ export class EmMap extends HTMLElement {
 
     const vectorAttr = this.getAttribute('vector-url') || this.getAttribute('vector-test-url')
     const vectorUrl = vectorAttr && vectorAttr.trim() ? vectorAttr : config.tiles.urls.localVectorStyleUrl
+    const attributionValue = this.getAttribute('attribution')?.trim() || ''
+    const attributionAllowHtml =
+      this.hasAttribute('attribution-allow-html') && this.getAttribute('attribution-allow-html') !== 'false'
 
     return {
       renderer,
@@ -562,6 +566,12 @@ export class EmMap extends HTMLElement {
       usesInternalOverlays: this.hasAttribute('uses-internal-overlays'),
       overlayBodyTemplateId: this.getAttribute('overlay-body-template-id') || undefined,
       overlayTitleTemplateId: this.getAttribute('overlay-title-template-id') || undefined,
+      attribution: attributionValue
+        ? {
+            value: attributionValue,
+            options: { allowHtml: attributionAllowHtml },
+          }
+        : undefined,
     }
   }
 
@@ -657,6 +667,10 @@ export class EmMap extends HTMLElement {
     const options = this.parseAttributes()
     const mapContainer = this.shadow.querySelector('#map') as HTMLElement
     const overlayEl = (this.shadow.querySelector('.app-map__overlay') as HTMLElement) ?? null
+
+    if (!this.pendingAttribution && options.attribution) {
+      this.pendingAttribution = options.attribution
+    }
 
     if (options.renderer === 'maplibre') {
       this.mapInstance = await setupMapLibreMap(

--- a/src/components/map/scripts/em-map.ts
+++ b/src/components/map/scripts/em-map.ts
@@ -12,7 +12,13 @@ import { setupMapLibreMap } from './core/setup/setup-maplibre-map'
 import { createMapDOM, createScopedStyle, getMapNonce } from './helpers/dom'
 import FeatureOverlay from './core/overlays/feature-overlay'
 import type { ComposableLayer, LayerStateOptions } from './core/layers/base'
-import { type MapAdapter, type MapLibrary, createOpenLayersAdapter, createMapLibreAdapter } from './core/map-adapter'
+import {
+  type AttributionOptions,
+  type MapAdapter,
+  type MapLibrary,
+  createOpenLayersAdapter,
+  createMapLibreAdapter,
+} from './core/map-adapter'
 import styles from '../styles/em-map.raw.css?raw'
 import { Position } from './core/types/position'
 import config from './core/config'
@@ -73,6 +79,8 @@ export class EmMap extends HTMLElement {
   private positionData: Array<Position> = []
 
   private mapInstance!: OLMapInstance | MapLibreMapInstance
+
+  private pendingAttribution?: { value: string; options?: AttributionOptions }
 
   constructor() {
     super()
@@ -232,6 +240,14 @@ export class EmMap extends HTMLElement {
 
   public closeOverlay() {
     this.featureOverlay?.close()
+  }
+
+  public setAttribution(value: string, options?: AttributionOptions): void {
+    this.pendingAttribution = { value, options }
+
+    if (!this.adapter) return
+
+    this.adapter.setAttribution(value, options)
   }
 
   public setLayerVisibility(idOrTitle: string, visible: boolean): void {
@@ -661,6 +677,10 @@ export class EmMap extends HTMLElement {
 
       const withOverlay: OLMapInstanceWithOverlay = this.mapInstance as OLMapInstanceWithOverlay
       this.featureOverlay = withOverlay.featureOverlay
+    }
+
+    if (this.pendingAttribution) {
+      this.adapter.setAttribution(this.pendingAttribution.value, this.pendingAttribution.options)
     }
   }
 

--- a/src/components/map/styles/_controls.scss
+++ b/src/components/map/styles/_controls.scss
@@ -195,3 +195,19 @@
   color: govuk-colour('mid-grey');
   outline: none;
 }
+
+:host .em-map__attribution {
+  position: absolute;
+  right: govuk-spacing(2);
+  bottom: govuk-spacing(2);
+  z-index: 10;
+  background: rgba(govuk-colour('white'), 0.92);
+  border: 1px solid govuk-colour('mid-grey');
+  padding: govuk-spacing(1) govuk-spacing(2);
+  @include govuk-font(14);
+  line-height: 1.3;
+}
+
+:host .em-map__attribution a {
+  color: govuk-colour('blue');
+}

--- a/src/components/map/styles/_controls.scss
+++ b/src/components/map/styles/_controls.scss
@@ -203,9 +203,9 @@
   z-index: 10;
   box-sizing: border-box;
   max-width: 33.333%;
-  background: rgba(govuk-colour('white'), 0.92);
-  border: 1px solid govuk-colour('mid-grey');
-  padding: govuk-spacing(1) govuk-spacing(2);
+  background: transparent;
+  border: 0;
+  padding: 0;
   @include govuk-font(14);
   line-height: 1.3;
   white-space: normal;

--- a/src/components/map/styles/_controls.scss
+++ b/src/components/map/styles/_controls.scss
@@ -203,10 +203,10 @@
   z-index: 10;
   box-sizing: border-box;
   max-width: 33.333%;
-  background: transparent;
-  border: 0;
-  padding: 0;
-  @include govuk-font(14);
+  background: rgba(govuk-colour('white'), 0.5);
+  padding: govuk-spacing(1) govuk-spacing(2);
+  color: govuk-colour('black');
+  @include govuk-font(16);
   line-height: 1.3;
   white-space: normal;
   overflow-wrap: anywhere;

--- a/src/components/map/styles/_controls.scss
+++ b/src/components/map/styles/_controls.scss
@@ -201,13 +201,20 @@
   right: govuk-spacing(2);
   bottom: govuk-spacing(2);
   z-index: 10;
+  box-sizing: border-box;
+  max-width: 33.333%;
   background: rgba(govuk-colour('white'), 0.92);
   border: 1px solid govuk-colour('mid-grey');
   padding: govuk-spacing(1) govuk-spacing(2);
   @include govuk-font(14);
   line-height: 1.3;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 :host .em-map__attribution a {
   color: govuk-colour('blue');
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }

--- a/src/components/map/styles/_controls.scss
+++ b/src/components/map/styles/_controls.scss
@@ -202,7 +202,7 @@
   bottom: govuk-spacing(1);
   z-index: 10;
   box-sizing: border-box;
-  max-width: 33.333%;
+  max-width: 40%;
   background: rgba(govuk-colour('white'), 0.5);
   padding: govuk-spacing(0) govuk-spacing(1);
   color: govuk-colour('black');

--- a/src/components/map/styles/_controls.scss
+++ b/src/components/map/styles/_controls.scss
@@ -198,13 +198,13 @@
 
 :host .em-map__attribution {
   position: absolute;
-  right: govuk-spacing(2);
-  bottom: govuk-spacing(2);
+  right: govuk-spacing(1);
+  bottom: govuk-spacing(1);
   z-index: 10;
   box-sizing: border-box;
   max-width: 33.333%;
   background: rgba(govuk-colour('white'), 0.5);
-  padding: govuk-spacing(1) govuk-spacing(2);
+  padding: govuk-spacing(0) govuk-spacing(1);
   color: govuk-colour('black');
   @include govuk-font(16);
   line-height: 1.3;

--- a/src/nunjucks/em-map/template.njk
+++ b/src/nunjucks/em-map/template.njk
@@ -35,6 +35,8 @@
       ol-rotate-tooltip="false"
     {% endif %}
   {% endif %}
+  {% if params.attribution %}attribution="{{ params.attribution | escape }}"{% endif %}
+  {% if params.attributionAllowHtml %}attribution-allow-html{% endif %}
   {% if params.controls.locationDisplay %}location-display="{{ params.controls.locationDisplay }}"{% endif %}
   {% if params.controls.enable3DBuildings %}enable-3d-buildings{% endif %}
   {% if params.controls.grabCursor is not defined or params.controls.grabCursor %}grab-cursor{% endif %}>

--- a/src/stories/map/setup-docs.mdx
+++ b/src/stories/map/setup-docs.mdx
@@ -221,6 +221,51 @@ From there, you can:
 
 ---
 
+### Attribution
+
+You can add map attribution either declaratively via attributes (including Nunjucks macro params) or at runtime in JavaScript.
+
+Declarative HTML:
+
+```html
+<em-map attribution="© Crown copyright"></em-map>
+```
+
+Allow sanitized links:
+
+```html
+<em-map
+  attribution="&lt;a href='https://example.test'&gt;© Ordnance Survey&lt;/a&gt;"
+  attribution-allow-html
+></em-map>
+```
+
+Nunjucks macro params:
+
+```njk
+{{ emMap({
+  cspNonce: cspNonce,
+  attribution: "© Crown copyright"
+}) }}
+```
+
+```njk
+{{ emMap({
+  cspNonce: cspNonce,
+  attribution: "<a href='https://example.test'>© Ordnance Survey</a>",
+  attributionAllowHtml: true
+}) }}
+```
+
+Runtime JavaScript:
+
+```js
+const emMap = document.querySelector('em-map')
+emMap.setAttribution('© Crown copyright')
+```
+
+---
+
 ### Layers
 
 Layers represent sets of features rendered on top of the base map - for example, locations, tracks, text, or circles showing GPS confidence.  

--- a/src/stories/map/setup-example.stories.ts
+++ b/src/stories/map/setup-example.stories.ts
@@ -7,6 +7,8 @@ type SetupStoryArgs = {
   enable3D: boolean
   positions: any[]
   usesInternalOverlays: boolean
+  attribution: string
+  attributionAllowHtml: boolean
   'controls.zoomControl': boolean
   'controls.zoomSlider': boolean
   'controls.rotate': 'true' | 'auto-hide' | 'false'
@@ -42,6 +44,16 @@ const meta = {
     usesInternalOverlays: {
       control: 'boolean',
       description: 'Enable click-to-open overlays (injects demo templates automatically)',
+    },
+    attribution: {
+      control: 'text',
+      table: { category: 'Attribution' },
+      description: 'Declarative attribution text or sanitized HTML',
+    },
+    attributionAllowHtml: {
+      control: 'boolean',
+      table: { category: 'Attribution' },
+      description: 'Allow sanitized HTML links in attribution',
     },
     'controls.zoomControl': {
       control: 'boolean',
@@ -141,6 +153,8 @@ const meta = {
       renderer: storyArgs.renderer,
       enable3D: storyArgs.enable3D,
       usesInternalOverlays: storyArgs.usesInternalOverlays,
+      attribution: storyArgs.attribution,
+      attributionAllowHtml: storyArgs.attributionAllowHtml,
       controls: {
         zoomControl: storyArgs['controls.zoomControl'],
         zoomSlider: storyArgs['controls.zoomSlider'],
@@ -175,6 +189,8 @@ export const Example: Story = {
     enable3D: true,
     positions,
     usesInternalOverlays: true,
+    attribution: "<a href='https://example.test'>© Ordnance Survey</a>",
+    attributionAllowHtml: true,
 
     'controls.zoomControl': true,
     'controls.zoomSlider': false,
@@ -198,6 +214,7 @@ export const Example: Story = {
         transform: (_src: string, context: StoryContext) => {
           const args = context.args as Record<string, any>
           const enable3D = args.renderer === 'maplibre' ? `\n  enable3DBuildings: ${args.enable3D},` : ''
+          const attribution = String(args.attribution || '').replaceAll("'", "\\\\'")
 
           const queryParams = new URLSearchParams()
           if (args['query.lat']) queryParams.set('lat', args['query.lat'])
@@ -230,6 +247,8 @@ export const Example: Story = {
   positions: positions,
   renderer: '${args.renderer}',${enable3D}
   usesInternalOverlays: ${args.usesInternalOverlays},
+  attribution: '${attribution}',
+  attributionAllowHtml: ${args.attributionAllowHtml},
   controls: {
     scaleControl: '${args['controls.scale']}',
     locationDisplay: '${args['controls.locationDisplay']}',

--- a/src/stories/map/setupMapDemo.ts
+++ b/src/stories/map/setupMapDemo.ts
@@ -46,6 +46,8 @@ interface MapDemoOptions {
     }
   }
   usesInternalOverlays?: boolean
+  attribution?: string
+  attributionAllowHtml?: boolean
   markerMode?: 'default' | 'pin' | 'pin-with-icon' | 'image' | 'mixed'
   includeViewportDemoLayers?: boolean
 }
@@ -205,6 +207,8 @@ export function setupMapDemo({
   showText = false,
   showCircles = false,
   usesInternalOverlays = true,
+  attribution,
+  attributionAllowHtml = false,
   markerMode = 'default',
   includeViewportDemoLayers = false,
   entryExit,
@@ -237,6 +241,9 @@ export function setupMapDemo({
   if (typeof controls.zoomControl === 'boolean') map.setAttribute('zoom-control', String(controls.zoomControl))
   if (typeof controls.zoomSlider === 'boolean') map.setAttribute('zoom-slider', String(controls.zoomSlider))
   if (typeof controls.grabCursor === 'boolean') map.setAttribute('grab-cursor', String(controls.grabCursor))
+
+  if (attribution) map.setAttribute('attribution', attribution)
+  if (attributionAllowHtml) map.setAttribute('attribution-allow-html', '')
 
   // Positions data
   const positionData = positions ?? defaultPositions


### PR DESCRIPTION
### Key Points

- These changes are designed to make it easier to add attribution for the map component.
- There are two ways to add the attribution: JS or HTML/Nunjucks.
- Attribution requirements depend on the specific use case and end users, so the default remains as "no attribution".

### Map with simple attribution
<img width="1322" height="822" alt="image" src="https://github.com/user-attachments/assets/c676d535-9fbf-4952-ad84-9951ab982d27" />


### Map with URL attribution
<img width="1322" height="822" alt="image" src="https://github.com/user-attachments/assets/1a0eef1b-eea3-47e4-8f07-d85b7b85c80c" />


### Example use in Downstream (JS)
<img width="857" height="833" alt="image" src="https://github.com/user-attachments/assets/50fafc9f-27a2-43c2-a76a-cfbf44a772fe" />

### Example use in Downstream (HTML)
<img width="869" height="588" alt="image" src="https://github.com/user-attachments/assets/f3d28836-777c-46c2-9676-bdb153d9193d" />

### Storybook Docs updated
<img width="1707" height="956" alt="image" src="https://github.com/user-attachments/assets/0f09cbda-e996-4835-895b-1ec61609b75c" />

